### PR TITLE
Fix int width for the LLP64 data model

### DIFF
--- a/include/spy.hpp
+++ b/include/spy.hpp
@@ -422,7 +422,7 @@ namespace spy
   constexpr inline auto lp32_   = detail::data_model_info<2,2,sizeof(long),4>{};
   constexpr inline auto silp64_ = detail::data_model_info<8,8,8,8>{};
   constexpr inline auto ilp64_  = detail::data_model_info<2,8,8,8>{};
-  constexpr inline auto llp64_  = detail::data_model_info<2,8,4,8>{};
+  constexpr inline auto llp64_  = detail::data_model_info<2,4,4,8>{};
   constexpr inline auto lp64_   = detail::data_model_info<2,4,8,8>{};
 }
 #include <cstddef>


### PR DESCRIPTION
Integers are 4 bytes wide on LLP64 platforms.

Sources:
- https://en.wikipedia.org/wiki/64-bit_computing
- https://en.cppreference.com/w/cpp/language/types