### PR TITLE
Move the wasm and riscv jobs to the v10 image

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,8 +23,8 @@ jobs:
           - { name: "aarch64 sve"  , preset: "gcc-aarch64-sve" , image: "v10" }
           - { name: "aarch64 sve2" , preset: "gcc-aarch64-sve2", image: "v10" }
           - { name: "ppc64"        , preset: "gcc-ppc64"       , image: "v10" }
-          - { name: "wasm"         , preset: "wasm"            , image: "v9"  }
-          - { name: "rvv128"       , preset: "rvv128"          , image: "v9"  }
+          - { name: "wasm"         , preset: "wasm"            , image: "v10" }
+          - { name: "rvv128"       , preset: "rvv128"          , image: "v10" }
           - { name: "icpx"         , preset: "icpx"            , image: "sycl-v1", setup: "/opt/intel/oneapi/setvars.sh" }
           - { name: "icpx sycl"    , preset: "icpx-sycl"       , image: "sycl-v1", setup: "/opt/intel/oneapi/setvars.sh" }
 

--- a/include/spy/compiler.hpp
+++ b/include/spy/compiler.hpp
@@ -124,8 +124,15 @@ namespace spy
 #undef SPY0
 #elif defined(__EMSCRIPTEN__)
 #define SPY_COMPILER_IS_CLANG
+// Emscripten 5 renamed these and marked the lower-case spelling deprecated, which -Werror turns
+// into a build failure. 4.x knows only the lower-case one, so both spellings stay supported.
+#if defined(__EMSCRIPTEN_MAJOR__)
+  using compiler_type =
+      _::emscripten_t<__EMSCRIPTEN_MAJOR__, __EMSCRIPTEN_MINOR__, __EMSCRIPTEN_TINY__>;
+#else
   using compiler_type =
       _::emscripten_t<__EMSCRIPTEN_major__, __EMSCRIPTEN_minor__, __EMSCRIPTEN_tiny__>;
+#endif
 #undef SPY0
 #elif defined(__clang__)
 #define SPY_COMPILER_IS_CLANG

--- a/test/toolchain/run_rvv128.sh
+++ b/test/toolchain/run_rvv128.sh
@@ -5,4 +5,7 @@
 ##==================================================================================================
 #!/bin/sh
 
-qemu-riscv64 --cpu rv64,v=true,vlen=128 $@
+# qemu 10 accepts v=true on the rv64 model and does nothing with it - the first vector
+# instruction traps. Only max exposes RVV, and the extensions this target does not have are
+# switched back off so the emulated hardware still matches -march=rv64gcv.
+qemu-riscv64 --cpu max,vlen=128,zfh=false,zvfh=false $@


### PR DESCRIPTION
Both were held back on v9, and it turned out to be for two unrelated reasons.

qemu 10 accepts v=true on the rv64 CPU model and does nothing with it: the first vector instruction raises SIGILL. Only max exposes RVV, so the runner script asks for it and switches off the extensions this target does not have, which keeps the emulated hardware matching -march=rv64gcv. Checked by running the same binary both ways inside the image: the old invocation exits 132, the new one exits 0, and the suite then passes 22 out of 22.

Emscripten 5 renamed __EMSCRIPTEN_major__ and marked the old spelling deprecated, which -Werror turns into a build failure, so the wasm build did not compile at all on v10. This is a header fix rather than a CI one: 4.x knows only the lower-case spelling and spy has to keep compiling against either, so both are honoured. Verified in both images, 22 out of 22 either way.