### PR TITLE
Add coverage and sanitizer builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 
 jobs:
   ##################################################################################################
-  ## Fast gate: pre-commit checks and standalone generation start together with no interdependency -
-  ## only once both pass does the (much heavier) compiler matrix start below.
+  ## Fast gate: pre-commit checks, standalone generation and sanitizers all start together with no
+  ## interdependency - only once all three pass does the (much heavier) compiler matrix start below.
   ##################################################################################################
   precommit:
     runs-on: ubuntu-latest
@@ -56,24 +56,38 @@ jobs:
           g++ -std=c++20 -S -I. ../test/integration/main.cpp -DSPY_STANDALONE
 
   ##################################################################################################
+  ## Sanitizers (ASan+UBSan)
+  ##################################################################################################
+  sanitizer-tests:
+    name: Sanitizers
+    uses: ./.github/workflows/sanitizers.yml
+
+  ##################################################################################################
+  ## Coverage report - informational, runs alongside the gate without blocking the matrix
+  ##################################################################################################
+  coverage-report:
+    name: Coverage
+    uses: ./.github/workflows/coverage.yml
+
+  ##################################################################################################
   ## Unit Tests - the full compiler matrix, gated behind the fast checks above all passing
   ##################################################################################################
   linux-tests:
     name: Linux
-    needs: [precommit, standalone-generation]
+    needs: [precommit, standalone-generation, sanitizer-tests]
     uses: ./.github/workflows/linux.yml
 
   macos-tests:
     name: MacOS
-    needs: [precommit, standalone-generation]
+    needs: [precommit, standalone-generation, sanitizer-tests]
     uses: ./.github/workflows/macos.yml
 
   windows-tests:
     name: Windows
-    needs: [precommit, standalone-generation]
+    needs: [precommit, standalone-generation, sanitizer-tests]
     uses: ./.github/workflows/windows.yml
 
   nvidia-tests:
     name: Nvidia
-    needs: [precommit, standalone-generation]
+    needs: [precommit, standalone-generation, sanitizer-tests]
     uses: ./.github/workflows/nvidia.yml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,72 @@
+##======================================================================================================================
+##  SPY - C++ Informations Broker
+##  Copyright : SPY Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+name: SPY Coverage
+on:
+  workflow_call:
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Debug
+          preset: gcc-coverage
+
+      - name: Run Unit Tests and Collect Coverage
+        shell: bash
+        run: cmake --build build/gcc-coverage --config Debug --target spy-coverage-report
+
+      - name: Report Coverage
+        shell: bash
+        run: |
+          python3 - "build/gcc-coverage/coverage/summary.json" >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          import json, sys
+
+          report = json.load(open(sys.argv[1]))
+
+          # gcovr reports no rate at all for a metric a header has no instance of - a branchless
+          # header is not 0% covered, it simply has nothing to say on that metric.
+          def rate(percent):
+            return "n/a" if percent is None else f"{percent:.1f}%"
+
+          def bar(percent):
+            filled = 0 if percent is None else round(percent / 5)
+            return "#" * filled + "." * (20 - filled)
+
+          print("## Coverage of `include/spy`\n")
+          print("| Metric | Covered | Total | Rate | |")
+          print("|---|---:|---:|---:|---|")
+          for name, key in [("Lines", "line"), ("Functions", "function"), ("Branches", "branch")]:
+            percent = report[f"{key}_percent"]
+            print(f"| {name} | {report[f'{key}_covered']} | {report[f'{key}_total']} "
+                  f"| {rate(percent)} | `{bar(percent)}` |")
+
+          print("\n<details><summary>Per-header breakdown</summary>\n")
+          print("| Header | Lines | Functions | Branches |")
+          print("|---|---:|---:|---:|")
+
+          # Worst first: the headers needing attention are the point of the table.
+          for entry in sorted(report["files"], key=lambda f: (f["line_percent"] is None, f["line_percent"])):
+            print(f"| `{entry['filename']}` | {rate(entry['line_percent'])} "
+                  f"| {rate(entry['function_percent'])} | {rate(entry['branch_percent'])} |")
+
+          print("\n</details>")
+          EOF
+
+      - name: Upload HTML Report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: build/gcc-coverage/coverage/

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,37 @@
+##======================================================================================================================
+##  SPY - C++ Informations Broker
+##  Copyright : SPY Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+name: SPY Sanitizers
+on:
+  workflow_call:
+
+jobs:
+  sanitizers:
+    name: ${{ matrix.compiler.name }} (ASan+UBSan)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { name: "gcc"  , preset: "gcc-sanitize"   }
+          - { name: "clang", preset: "clang-sanitize" }
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Debug
+          preset: ${{ matrix.compiler.preset }}
+
+      - name: Run Unit Tests
+        uses: ./.github/actions/test
+        with:
+          config: Debug
+          preset: ${{ matrix.compiler.preset }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ cmake_minimum_required(VERSION 3.22)
 project(spy LANGUAGES CXX)
 
 ##======================================================================================================================
-option( SPY_BUILD_TEST          "Build tests   for SPY"   ON  )
-option( SPY_BUILD_DOCUMENTATION "Build Doxygen for SPY"   OFF )
+option( SPY_BUILD_TEST          "Build tests   for SPY"                                        ON  )
+option( SPY_BUILD_DOCUMENTATION "Build Doxygen for SPY"                                        OFF )
+option( SPY_ENABLE_SANITIZERS   "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF )
+option( SPY_ENABLE_COVERAGE     "Build tests with code coverage instrumentation"                 OFF )
 
 ##======================================================================================================================
 include(${PROJECT_SOURCE_DIR}/cmake/dependencies.cmake)
@@ -33,6 +35,8 @@ if(NOT SPY_QUIET)
   endif()
   message(STATUS "[${PROJECT_NAME}] - Unit tests : ${SPY_BUILD_TEST} (via SPY_BUILD_TEST)")
   message(STATUS "[${PROJECT_NAME}] - Doxygen    : ${SPY_BUILD_DOCUMENTATION} (via SPY_BUILD_DOCUMENTATION)")
+  message(STATUS "[${PROJECT_NAME}] - Sanitizers : ${SPY_ENABLE_SANITIZERS} (via SPY_ENABLE_SANITIZERS)")
+  message(STATUS "[${PROJECT_NAME}] - Coverage   : ${SPY_ENABLE_COVERAGE} (via SPY_ENABLE_COVERAGE)")
   set(QUIET_OPTION "")
 else()
   set(QUIET_OPTION "QUIET")
@@ -71,7 +75,16 @@ copa_setup_standalone ( QUIET
 ## Tests setup
 ##======================================================================================================================
 if(SPY_BUILD_TEST)
+  if(SPY_ENABLE_SANITIZERS)
+    copa_setup_sanitizers(spy_tests ENABLE_ASAN ENABLE_UBSAN)
+  endif()
+
   enable_testing()
   add_custom_target(spy-unit)
   add_subdirectory(test)
+
+  # After the test targets exist, so the coverage targets can depend on them
+  if(SPY_ENABLE_COVERAGE)
+    copa_setup_coverage(spy_tests)
+  endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,6 +33,17 @@
       "architecture": "x64"
     },
 
+    {
+      "name": "sanitize",
+      "hidden": true,
+      "cacheVariables": { "SPY_ENABLE_SANITIZERS": "ON" }
+    },
+    {
+      "name": "coverage",
+      "hidden": true,
+      "cacheVariables": { "SPY_ENABLE_COVERAGE": "ON", "CMAKE_DEFAULT_BUILD_TYPE": "Debug" }
+    },
+
     { "name": "gcc"             , "inherits": ["unix-base"], "toolchainFile": "${sourceDir}/test/toolchain/gcc.x86.cmake"          },
     { "name": "clang"           , "inherits": ["unix-base"], "toolchainFile": "${sourceDir}/test/toolchain/clang.x86.cmake"        },
     { "name": "gcc-aarch64"     , "inherits": ["unix-base"], "toolchainFile": "${sourceDir}/test/toolchain/gcc.aarch64.cmake"      },
@@ -45,6 +56,11 @@
     { "name": "icpx-sycl"       , "inherits": ["unix-base"], "toolchainFile": "${sourceDir}/test/toolchain/dpcpp.sycl.cmake"       },
     { "name": "clang-macos"     , "inherits": ["unix-base"], "toolchainFile": "${sourceDir}/test/toolchain/clang.aarch64.cmake"    },
 
+    { "name": "gcc-sanitize"    , "inherits": ["gcc"  , "sanitize"] },
+    { "name": "gcc-coverage"    , "inherits": ["gcc"  , "coverage"] },
+    { "name": "clang-sanitize"  , "inherits": ["clang", "sanitize"] },
+    { "name": "clang-coverage"  , "inherits": ["clang", "coverage"] },
+
     { "name": "msvc"    , "inherits": ["windows-base"]                      },
     { "name": "clangcl" , "inherits": ["windows-base"], "toolset": "ClangCL" }
   ],
@@ -52,6 +68,10 @@
     { "name": "base-build", "hidden": true, "targets": ["spy-test"] },
     { "name": "gcc"             , "inherits": "base-build", "configurePreset": "gcc"              },
     { "name": "clang"           , "inherits": "base-build", "configurePreset": "clang"            },
+    { "name": "gcc-sanitize"    , "inherits": "base-build", "configurePreset": "gcc-sanitize"     },
+    { "name": "gcc-coverage"    , "inherits": "base-build", "configurePreset": "gcc-coverage"     },
+    { "name": "clang-sanitize"  , "inherits": "base-build", "configurePreset": "clang-sanitize"   },
+    { "name": "clang-coverage"  , "inherits": "base-build", "configurePreset": "clang-coverage"   },
     { "name": "gcc-aarch64"     , "inherits": "base-build", "configurePreset": "gcc-aarch64"      },
     { "name": "gcc-aarch64-sve" , "inherits": "base-build", "configurePreset": "gcc-aarch64-sve"  },
     { "name": "gcc-aarch64-sve2", "inherits": "base-build", "configurePreset": "gcc-aarch64-sve2" },
@@ -68,6 +88,10 @@
     { "name": "base-test", "hidden": true, "output": { "outputOnFailure": true }, "configuration": "Debug" },
     { "name": "gcc"             , "inherits": "base-test", "configurePreset": "gcc"              },
     { "name": "clang"           , "inherits": "base-test", "configurePreset": "clang"            },
+    { "name": "gcc-sanitize"    , "inherits": "base-test", "configurePreset": "gcc-sanitize"     },
+    { "name": "gcc-coverage"    , "inherits": "base-test", "configurePreset": "gcc-coverage"     },
+    { "name": "clang-sanitize"  , "inherits": "base-test", "configurePreset": "clang-sanitize"   },
+    { "name": "clang-coverage"  , "inherits": "base-test", "configurePreset": "clang-coverage"   },
     { "name": "gcc-aarch64"     , "inherits": "base-test", "configurePreset": "gcc-aarch64"      },
     { "name": "gcc-aarch64-sve" , "inherits": "base-test", "configurePreset": "gcc-aarch64-sve"  },
     { "name": "gcc-aarch64-sve2", "inherits": "base-test", "configurePreset": "gcc-aarch64-sve2" },


### PR DESCRIPTION
Both ride on spy_tests, and the compiler matrix now waits on the sanitizer jobs the way it already waited on pre-commit and the standalone generation. Coverage runs alongside the gate without blocking it, as it does in TTS.

Measured in the CI image: the sanitizers pass 22 tests out of 22, and coverage reports 100% of lines and 100% of functions. No branches, which is what a library made almost entirely of constexpr and type traits should report rather than a zero worth worrying about.

Coverage collects with gcc only. The image pairs clang 19 with llvm-cov 20, and copa_setup_coverage refuses that pairing at configure time - llvm-cov reads no notes written by another major - rather than letting gcovr produce a report from data it cannot read. The clang-coverage preset stays for anyone whose two versions do match.

This adds three checks, so the ruleset needs them before it can gate on them: Sanitizers / gcc (ASan+UBSan), Sanitizers / clang (ASan+UBSan), and Coverage / Coverage - the last one informational, left out of the required list in TTS and kumi alike.