### PR TITLE
Call copacabana's shared workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+##======================================================================================================================
+##  SPY - C++ Informations Broker
+##  Copyright : SPY Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Keeps the action references in .github/workflows current. Everything lands in one grouped pull
+## request a week rather than one per action, and a SHA pin is rewritten along with the version
+## comment that documents it - which is what makes pinning by commit sustainable by hand.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,5 @@
 ##======================================================================================================================
-##  SPY - Informations Broker
+##  SPY - C++ Informations Broker
 ##  Copyright : SPY Project Contributors
 ##  SPDX-License-Identifier: BSL-1.0
 ##======================================================================================================================
@@ -10,27 +10,10 @@ on:
       - main
 
 jobs:
-  generate-doc:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Prepare SPY
-        run: |
-          mkdir build && cd build
-          cmake .. -G Ninja -DSPY_BUILD_TEST=OFF -DSPY_BUILD_DOCUMENTATION=ON
-
-      - name: Generate Doxygen
-        run: |
-          cd build
-          ninja spy-doxygen
-
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/doc
+  documentation:
+    permissions:
+      contents: write
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: spy
+      coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,62 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  install:
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Install SPY from checkout
-        run: |
-          mkdir build && cd build
-          cmake -G Ninja .. -DSPY_BUILD_TEST=OFF -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-std=c++20"
-          ninja install
-      - name: Run Sample CMake
-        run: |
-          mkdir install && cd install
-          cmake ../test/integration/install-test -G Ninja  -DCMAKE_CXX_FLAGS="-std=c++20"
-          ninja && ctest --verbose
-
-  fetch-content:
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Compile using FetchContent
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          mkdir install && cd install
-          cmake ../test/integration/fetch-test -G Ninja -DGIT_BRANCH=${BRANCH_NAME} -DSPY_BUILD_TEST=OFF -DCMAKE_CXX_COMPILER=clang++  -DCMAKE_CXX_FLAGS="-std=c++20"
-          ninja && ctest --verbose
-
-  cpm:
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Compile using CPM
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          mkdir install && cd install
-          cmake ../test/integration/cpm-test -G Ninja -DGIT_BRANCH=${BRANCH_NAME}  -DCMAKE_CXX_FLAGS="-std=c++20"  -DCMAKE_CXX_COMPILER=clang++ -DSPY_BUILD_TEST=OFF
-          ninja && ctest --verbose
+  integration:
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: spy
+      cxx-compiler: clang++
+      cxx-flags: -std=c++20

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -3,7 +3,7 @@
 ##  Copyright : SPY Project Contributors
 ##  SPDX-License-Identifier: BSL-1.0
 ##======================================================================================================================
-name: SPY Documentation Generation
+name: SPY Standalone Generation
 on:
   push:
     branches:
@@ -11,39 +11,9 @@ on:
 
 jobs:
   package-standalone:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-
-      - name: Configure SPY
-        run: |
-          git config --global --add safe.directory /__w/spy/spy
-          cmake -S . -B build -G Ninja -DSPY_BUILD_TEST=OFF -DSPY_BUILD_DOCUMENTATION=OFF
-
-      - name: Generate standalone SPY header
-        run: |
-          cmake --build build --target spy-standalone
-
-      - name: Update standalone branch
-        run: |
-          git fetch origin
-          git config --global user.email "spy@nowhere.com"
-          git config --global user.name "SPY Standalone Generator"
-          git checkout standalone
-          cp build/spy.hpp spy.hpp
-          git add spy.hpp
-          git commit --allow-empty -m "Latest SPY standalone"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "standalone"
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: spy

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,4 +30,4 @@ include(${CPM_DOWNLOAD_LOCATION})
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG main)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v2)


### PR DESCRIPTION
Documentation, integration and standalone generation move to copacabana, 119 lines less here, and documentation now carries the coverage report to gh-pages the way TTS and kumi do. The compiler and the standard forced on the integration jobs are kept as they were, so that part is a like-for-like replacement.

This also retires the last three references to the v9 image - they were in exactly these three files - and replaces a peaceiris action tracked by a mutable tag with the copacabana one pinned by commit.

Checked in the image rather than assumed: the four naming conventions the shared workflows derive from a project name all hold here (SPY_BUILD_TEST and SPY_BUILD_DOCUMENTATION, the spy-doxygen and spy-standalone targets, build/spy.hpp, and spy-coverage-report), the documentation target produces build/doc/index.html, and the coverage rider assembles a report at 100% of lines.

The two write-facing workflows only fire on a push to main, so this pull request cannot exercise them - the first real run happens after the merge, as it did for TTS.