### PR TITLE
Drive the nvidia jobs from presets too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+##======================================================================================================================
+##  SPY - C++ Informations Broker
+##  Copyright : SPY Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Keeps the action references in .github/workflows current. Everything lands in one grouped pull
+## request a week rather than one per action, and a SHA pin is rewritten along with the version
+## comment that documents it - which is what makes pinning by commit sustainable by hand.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,5 +1,5 @@
 ##======================================================================================================================
-##  SPY - Informations Broker
+##  SPY - C++ Informations Broker
 ##  Copyright : SPY Project Contributors
 ##  SPDX-License-Identifier: BSL-1.0
 ##======================================================================================================================
@@ -10,27 +10,10 @@ on:
       - main
 
 jobs:
-  generate-doc:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Prepare SPY
-        run: |
-          mkdir build && cd build
-          cmake .. -G Ninja -DSPY_BUILD_TEST=OFF -DSPY_BUILD_DOCUMENTATION=ON
-
-      - name: Generate Doxygen
-        run: |
-          cd build
-          ninja spy-doxygen
-
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/doc
+  documentation:
+    permissions:
+      contents: write
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: spy
+      coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,62 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  install:
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Install SPY from checkout
-        run: |
-          mkdir build && cd build
-          cmake -G Ninja .. -DSPY_BUILD_TEST=OFF -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-std=c++20"
-          ninja install
-      - name: Run Sample CMake
-        run: |
-          mkdir install && cd install
-          cmake ../test/integration/install-test -G Ninja  -DCMAKE_CXX_FLAGS="-std=c++20"
-          ninja && ctest --verbose
-
-  fetch-content:
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Compile using FetchContent
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          mkdir install && cd install
-          cmake ../test/integration/fetch-test -G Ninja -DGIT_BRANCH=${BRANCH_NAME} -DSPY_BUILD_TEST=OFF -DCMAKE_CXX_COMPILER=clang++  -DCMAKE_CXX_FLAGS="-std=c++20"
-          ninja && ctest --verbose
-
-  cpm:
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: [ubuntu-latest]
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Compile using CPM
-        run: |
-          git config --global --add safe.directory /__w/kumi/kumi
-          mkdir install && cd install
-          cmake ../test/integration/cpm-test -G Ninja -DGIT_BRANCH=${BRANCH_NAME}  -DCMAKE_CXX_FLAGS="-std=c++20"  -DCMAKE_CXX_COMPILER=clang++ -DSPY_BUILD_TEST=OFF
-          ninja && ctest --verbose
+  integration:
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: spy
+      cxx-compiler: clang++
+      cxx-flags: -std=c++20

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -8,35 +8,30 @@ on:
   workflow_call:
 
 jobs:
-  nvcc:
+  nvidia:
+    name: ${{ matrix.compiler.name }} (${{ matrix.options }})
     runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
-        cfg:
-        - { comp: nvcc    , opt: "" }
-        - { comp: clang++ , opt: "--cuda-gpu-arch=sm_75 -lcudart_static -L/opt/cuda/lib64/ -ldl -lrt -pthread"  }
+        compiler:
+          - { name: "nvcc"      , preset: "nvcc"       }
+          - { name: "clang-cuda", preset: "clang-cuda" }
+
+        options: [Debug, Release]
+
     steps:
       - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-      - name: Compiling Unit Tests with ${{ matrix.cfg.comp }}
-        run:  |
-              mkdir build && cd build
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/accelerator.cu -std=c++20 -I../include -o accelerator.device.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/accelerator.cpp -std=c++20 -I../include -o accelerator.host.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/arch.cpp -std=c++20 -I../include -o arch.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/compiler.cpp -std=c++20 -I../include -o compiler.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/data_model.cpp -std=c++20 -I../include -o data_model.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/libc.cpp -std=c++20 -I../include -o libc.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/os.cpp -std=c++20 -I../include -o os.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/simd.cpp -std=c++20 -I../include -o simd.exe
-              ${{ matrix.cfg.comp }} ${{ matrix.cfg.opt }} ../test/unit/stdlib.cpp -std=c++20 -I../include -o stdlib.exe
-      - name: Running Unit Tests
-        run:  |
-              cd build
-              ./accelerator.device.exe && ./accelerator.host.exe && ./arch.exe && ./compiler.exe && ./data_model.exe && \
-              ./libc.exe && ./os.exe && ./simd.exe && ./stdlib.exe
+        uses: actions/checkout@v6
 
-  ##################################################################################################
-  ## DPC++ Target
-  ##################################################################################################
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: ${{ matrix.options }}
+          preset: ${{ matrix.compiler.preset }}
+
+      - name: Run Unit Tests
+        uses: ./.github/actions/test
+        with:
+          config: ${{ matrix.options }}
+          preset: ${{ matrix.compiler.preset }}

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -3,7 +3,7 @@
 ##  Copyright : SPY Project Contributors
 ##  SPDX-License-Identifier: BSL-1.0
 ##======================================================================================================================
-name: SPY Documentation Generation
+name: SPY Standalone Generation
 on:
   push:
     branches:
@@ -11,39 +11,9 @@ on:
 
 jobs:
   package-standalone:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    container:
-      image: ghcr.io/jfalcou/compilers:v9
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Fetch current branch
-        uses: actions/checkout@v6.0.2
-
-      - name: Configure SPY
-        run: |
-          git config --global --add safe.directory /__w/spy/spy
-          cmake -S . -B build -G Ninja -DSPY_BUILD_TEST=OFF -DSPY_BUILD_DOCUMENTATION=OFF
-
-      - name: Generate standalone SPY header
-        run: |
-          cmake --build build --target spy-standalone
-
-      - name: Update standalone branch
-        run: |
-          git fetch origin
-          git config --global user.email "spy@nowhere.com"
-          git config --global user.name "SPY Standalone Generator"
-          git checkout standalone
-          cp build/spy.hpp spy.hpp
-          git add spy.hpp
-          git commit --allow-empty -m "Latest SPY standalone"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: "standalone"
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    with:
+      project: spy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@
 cmake_minimum_required(VERSION 3.22)
 project(spy LANGUAGES CXX)
 
+if(DEFINED CMAKE_CUDA_COMPILER)
+  enable_language(CUDA)
+endif()
+
 ##======================================================================================================================
 option( SPY_BUILD_TEST          "Build tests   for SPY"                                        ON  )
 option( SPY_BUILD_DOCUMENTATION "Build Doxygen for SPY"                                        OFF )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -34,6 +34,13 @@
     },
 
     {
+      "name": "nvidia-base",
+      "hidden": true,
+      "inherits": ["base"],
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": { "CMAKE_CUDA_COMPILER": "nvcc", "CMAKE_DEFAULT_BUILD_TYPE": "Debug" }
+    },
+    {
       "name": "sanitize",
       "hidden": true,
       "cacheVariables": { "SPY_ENABLE_SANITIZERS": "ON" }
@@ -61,6 +68,17 @@
     { "name": "clang-sanitize"  , "inherits": ["clang", "sanitize"] },
     { "name": "clang-coverage"  , "inherits": ["clang", "coverage"] },
 
+    { "name": "nvcc"            , "inherits": ["nvidia-base"] },
+    {
+      "name": "clang-cuda",
+      "inherits": ["unix-base"],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CUDA_COMPILER": "clang++",
+        "CMAKE_CUDA_ARCHITECTURES": "75"
+      }
+    },
+
     { "name": "msvc"    , "inherits": ["windows-base"]                      },
     { "name": "clangcl" , "inherits": ["windows-base"], "toolset": "ClangCL" }
   ],
@@ -72,6 +90,8 @@
     { "name": "gcc-coverage"    , "inherits": "base-build", "configurePreset": "gcc-coverage"     },
     { "name": "clang-sanitize"  , "inherits": "base-build", "configurePreset": "clang-sanitize"   },
     { "name": "clang-coverage"  , "inherits": "base-build", "configurePreset": "clang-coverage"   },
+    { "name": "nvcc"            , "inherits": "base-build", "configurePreset": "nvcc"             },
+    { "name": "clang-cuda"      , "inherits": "base-build", "configurePreset": "clang-cuda"       },
     { "name": "gcc-aarch64"     , "inherits": "base-build", "configurePreset": "gcc-aarch64"      },
     { "name": "gcc-aarch64-sve" , "inherits": "base-build", "configurePreset": "gcc-aarch64-sve"  },
     { "name": "gcc-aarch64-sve2", "inherits": "base-build", "configurePreset": "gcc-aarch64-sve2" },
@@ -92,6 +112,8 @@
     { "name": "gcc-coverage"    , "inherits": "base-test", "configurePreset": "gcc-coverage"     },
     { "name": "clang-sanitize"  , "inherits": "base-test", "configurePreset": "clang-sanitize"   },
     { "name": "clang-coverage"  , "inherits": "base-test", "configurePreset": "clang-coverage"   },
+    { "name": "nvcc"            , "inherits": "base-test", "configurePreset": "nvcc"             },
+    { "name": "clang-cuda"      , "inherits": "base-test", "configurePreset": "clang-cuda"       },
     { "name": "gcc-aarch64"     , "inherits": "base-test", "configurePreset": "gcc-aarch64"      },
     { "name": "gcc-aarch64-sve" , "inherits": "base-test", "configurePreset": "gcc-aarch64-sve"  },
     { "name": "gcc-aarch64-sve2", "inherits": "base-test", "configurePreset": "gcc-aarch64-sve2" },

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -13,14 +13,14 @@ target_compile_features ( spy_tests INTERFACE  cxx_std_20 )
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-    target_compile_options( spy_tests INTERFACE /W3 /EHsc )
+    target_compile_options( spy_tests INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/W3 /EHsc> )
   else()
-    target_compile_options( spy_tests INTERFACE -Werror -Wall -Wextra -Wunused-variable -Wshadow -Wdocumentation)
+    target_compile_options( spy_tests INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Werror -Wall -Wextra -Wunused-variable -Wshadow -Wdocumentation>)
   endif()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options( spy_tests INTERFACE /W3 /EHsc /Zc:preprocessor)
+  target_compile_options( spy_tests INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/W3 /EHsc /Zc:preprocessor>)
 else()
-  target_compile_options( spy_tests INTERFACE -Werror -Wall -Wextra -Wunused-variable -Wshadow)
+  target_compile_options( spy_tests INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Werror -Wall -Wextra -Wunused-variable -Wshadow>)
 endif()
 
 target_include_directories( spy_tests INTERFACE

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -30,4 +30,4 @@ include(${CPM_DOWNLOAD_LOCATION})
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG main)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,3 +7,15 @@ copa_setup_test_targets()
 set(root "${CMAKE_SOURCE_DIR}/test")
 copa_glob_unit(QUIET PATTERN "unit/*.cpp"     INTERFACE spy_tests)
 copa_glob_unit(QUIET PATTERN "samples/*.cpp"  INTERFACE spy_tests)
+
+##======================================================================================================================
+## accelerator.cpp and accelerator.cu are the same test compiled twice: as plain C++ spy must
+## report no CUDA, as CUDA it must report some. Only the second needs a CUDA compiler to exist.
+##======================================================================================================================
+if(CMAKE_CUDA_COMPILER)
+  copa_make_single_unit( INTERFACE spy_tests
+                         FILES     unit/accelerator.cu
+                         ROOT      ${root}
+                         NAME      unit.accelerator.device.cu
+                       )
+endif()


### PR DESCRIPTION
The job compiled every test by hand, one command per file, which is why it was left alone when the rest of the CI moved to presets. accelerator.cu now builds as a CUDA target next to accelerator.cpp - the same test twice, once where spy must report CUDA and once where it must not - and the two configurations the job used become the nvcc and clang-cuda presets.

None of the CUDA side is verifiable without a toolkit, and there is none here, so the self-hosted runner is what proves this one. What could be checked was checked: with no CUDA compiler the .cu target is skipped and the ordinary build still passes its 22 tests, so nothing outside the nvidia jobs moves.

The check names change, so the ruleset needs updating before it can gate on them. Going away: Nvidia / nvcc (nvcc) and Nvidia / nvcc (clang++, --cuda-gpu-arch=sm_75 -lcudart_static -L/opt/cuda/lib64/ -ldl -lrt -pthread). Arriving: Nvidia / nvcc (Debug), Nvidia / nvcc (Release), Nvidia / clang-cuda (Debug) and Nvidia / clang-cuda (Release) - four instead of two, since the presets carry Debug and Release.