### PR TITLE
Point the CI badge at a workflow that still exists, and add coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
 [![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.gg/a9qVaEMeXd8)
-[![CI Status](https://github.com/jfalcou/spy/actions/workflows/unit.yml/badge.svg)](https://github.com/jfalcou/spy/actions/workflows/unit.yml)
+[![CI Status](https://github.com/jfalcou/spy/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/spy/actions/workflows/integration.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/spy/coverage/badge.json&style=plastic&cacheSeconds=1800)](https://jfalcou.github.io/spy/coverage/)
 
 <br clear="left"/>
 


### PR DESCRIPTION
unit.yml was split into ci.yml and the per-platform files, so the CI badge pointed at nothing. It now tracks integration.yml, as TTS and kumi do: ci.yml only runs on pull requests and has no branch status to show.

The coverage report reaches gh-pages with the documentation now, so the badge has a source. cacheSeconds is set from the start, since GitHub's image proxy keeps whatever it fetched first.