### PR TITLE
Pin SPY_BUILD_TEST in the fetch integration test

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -5,8 +5,7 @@
 ##======================================================================================================================
 
 ##======================================================================================================================
-## CPM is vendored rather than fetched: file(DOWNLOAD) reports nothing on a failure, so a network
-## hiccup leaves an empty file and CMake only complains later that CPMAddPackage does not exist.
+## CPM is vendored: the download bootstrap reports nothing on a failure and leaves an empty file.
 ##======================================================================================================================
 include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 

--- a/test/integration/fetch-test/CMakeLists.txt
+++ b/test/integration/fetch-test/CMakeLists.txt
@@ -18,6 +18,9 @@ FetchContent_Declare(spy
   GIT_TAG ${GIT_BRANCH}
 )
 
+## FetchContent has no per-package OPTIONS: what spy reads is pinned here.
+set(SPY_BUILD_TEST OFF CACHE BOOL "" FORCE)
+
 # make available
 FetchContent_MakeAvailable(spy)
 


### PR DESCRIPTION
The option was left to whoever configured the project, which the workflow happens to do. On its own the test registered the whole suite instead of the single case it is there to check. cpm-test already carried its options in the file.