### PR TITLE
Move to copacabana v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   ##################################################################################################
   precommit:
     name: Meta Checks
-    uses: jfalcou/copacabana/.github/workflows/precommit.yml@bdd4698a6b7653510904e7e408298c574591af69 # v5
+    uses: jfalcou/copacabana/.github/workflows/precommit.yml@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
 
   ##======================================================================================================================
   ## Ensure Standalone is viable
@@ -49,14 +49,14 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
-    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@bdd4698a6b7653510904e7e408298c574591af69 # v5
+    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
 
   ##################################################################################################
   ## Coverage report - informational, runs alongside the gate without blocking the matrix
   ##################################################################################################
   coverage-report:
     name: Coverage
-    uses: jfalcou/copacabana/.github/workflows/coverage.yml@bdd4698a6b7653510904e7e408298c574591af69 # v5
+    uses: jfalcou/copacabana/.github/workflows/coverage.yml@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
     with:
       project: spy
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@bdd4698a6b7653510904e7e408298c574591af69 # v5
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
     with:
       project: spy
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@bdd4698a6b7653510904e7e408298c574591af69 # v5
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
     with:
       project: spy
       cxx-compiler: clang++

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,14 +35,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure CMake and Build
-        uses: jfalcou/copacabana/.github/actions/config@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/config@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: ${{ matrix.compiler.preset }}
           setup-script: ${{ matrix.compiler.setup }}
 
       - name: Run Unit Tests
-        uses: jfalcou/copacabana/.github/actions/test@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/test@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: ${{ matrix.compiler.preset }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,13 +21,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure CMake and Build
-        uses: jfalcou/copacabana/.github/actions/config@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/config@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: clang-macos
 
       - name: Run Unit Tests
-        uses: jfalcou/copacabana/.github/actions/test@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/test@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: clang-macos

--- a/.github/workflows/nvidia.yml
+++ b/.github/workflows/nvidia.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure CMake and Build
-        uses: jfalcou/copacabana/.github/actions/config@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/config@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: ${{ matrix.compiler.preset }}
 
       - name: Run Unit Tests
-        uses: jfalcou/copacabana/.github/actions/test@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/test@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: ${{ matrix.compiler.preset }}

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@bdd4698a6b7653510904e7e408298c574591af69 # v5
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
     with:
       project: spy

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure CMake and Build
-        uses: jfalcou/copacabana/.github/actions/config@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/config@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: ${{ matrix.compiler.preset }}
 
       - name: Run Unit Tests
-        uses: jfalcou/copacabana/.github/actions/test@bdd4698a6b7653510904e7e408298c574591af69 # v5
+        uses: jfalcou/copacabana/.github/actions/test@468da45ac73a026a4bca4510840ebe635aa66c2c # v6
         with:
           config: ${{ matrix.options }}
           preset: ${{ matrix.compiler.preset }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 ##======================================================================================================================
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake ${COPACABANA_SOURCE_DIR}/copacabana/cmake)
 include(${COPACABANA_SOURCE_DIR}/copacabana/cmake/copacabana.cmake)
-copa_project_version(MAJOR 2 MINOR 0 PATCH 0)
+copa_project_version(MAJOR 2 MINOR 0 PATCH 0 REPOSITORY https://github.com/jfalcou/spy)
 
 ##======================================================================================================================
 ## Summary Display
@@ -67,7 +67,6 @@ if(SPY_BUILD_DOCUMENTATION)
   copa_setup_doxygen(${QUIET_OPTION}
                      TARGET spy-doxygen
                      DESTINATION "${PROJECT_BINARY_DIR}/doc"
-                     URL "https://github.com/jfalcou/spy"
                      GODBOLT_LIBRARIES spy
                      GODBOLT_COMPILER clang1600
                      GODBOLT_OPTIONS "-O3 -std=c++20 -DNDEBUG"

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -12,4 +12,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v5)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v6)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -28,8 +28,3 @@ GENERATE_LATEX         = NO
 ## What the fleet shares, last so that it wins over anything above
 ##======================================================================================================================
 @INCLUDE               = $(DOXYGEN_ASSETS)/base.doxyfile
-
-## What this project adds on top of it. color.css is written into the output by copa_setup_doxygen, from the same
-## numbers that tint doxygen's own widgets.
-HTML_EXTRA_STYLESHEET += $(DOXYGEN_ASSETS)/custom.css
-HTML_EXTRA_STYLESHEET += $(DOXYGEN_OUPUT)/color.css


### PR DESCRIPTION
Both pins move together. The two stylesheets the Doxyfile named are in the shared fragment now, so it drops them; the GitHub corner stops linking to a literal `$(DOXYGEN_PROJECT_URL)`, and Doxygen no longer adds a copy button on top of the theme's own.