### PR TITLE
Add a MINGW64 row to the Windows matrix

### DIFF
--- a/.github/matrices/windows.yml
+++ b/.github/matrices/windows.yml
@@ -8,3 +8,4 @@ runs-on: windows-2022
 rows:
   - { name: "msvc"    , preset: "msvc"    }
   - { name: "clang-cl", preset: "clangcl" }
+  - { name: "mingw64" , preset: "mingw64", setup: "test/toolchain/setup_mingw64.sh" }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -80,7 +80,12 @@
     },
 
     { "name": "msvc"    , "inherits": ["windows-base"]                      },
-    { "name": "clangcl" , "inherits": ["windows-base"], "toolset": "ClangCL" }
+    { "name": "clangcl" , "inherits": ["windows-base"], "toolset": "ClangCL" },
+
+    { "name": "mingw64" , "inherits": ["base"], "generator": "Ninja Multi-Config"
+    , "toolchainFile": "${sourceDir}/test/toolchain/gcc.mingw64.cmake"
+    , "cacheVariables": { "CMAKE_DEFAULT_BUILD_TYPE": "Debug" }
+    }
   ],
   "buildPresets": [
     { "name": "base-build", "hidden": true, "targets": ["spy-test"] },
@@ -102,7 +107,8 @@
     { "name": "icpx-sycl"       , "inherits": "base-build", "configurePreset": "icpx-sycl"        },
     { "name": "clang-macos"     , "inherits": "base-build", "configurePreset": "clang-macos"      },
     { "name": "msvc"            , "inherits": "base-build", "configurePreset": "msvc"             },
-    { "name": "clangcl"         , "inherits": "base-build", "configurePreset": "clangcl"          }
+    { "name": "clangcl"         , "inherits": "base-build", "configurePreset": "clangcl"          },
+    { "name": "mingw64"         , "inherits": "base-build", "configurePreset": "mingw64"          }
   ],
   "testPresets": [
     { "name": "base-test", "hidden": true, "output": { "outputOnFailure": true }, "configuration": "Debug" },
@@ -124,6 +130,7 @@
     { "name": "icpx-sycl"       , "inherits": "base-test", "configurePreset": "icpx-sycl"        },
     { "name": "clang-macos"     , "inherits": "base-test", "configurePreset": "clang-macos"      },
     { "name": "msvc"            , "inherits": "base-test", "configurePreset": "msvc"             },
-    { "name": "clangcl"         , "inherits": "base-test", "configurePreset": "clangcl"          }
+    { "name": "clangcl"         , "inherits": "base-test", "configurePreset": "clangcl"          },
+    { "name": "mingw64"         , "inherits": "base-test", "configurePreset": "mingw64"          }
   ]
 }

--- a/test/toolchain/gcc.mingw64.cmake
+++ b/test/toolchain/gcc.mingw64.cmake
@@ -1,0 +1,17 @@
+##==================================================================================================
+##  SPY - C++ Informations Broker
+##  Copyright : SPY Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##==================================================================================================
+## MINGW64_BIN is set by test/toolchain/setup_mingw64.sh, which the CI row sources before configuring.
+if(DEFINED ENV{MINGW64_BIN})
+  set(CMAKE_C_COMPILER    "$ENV{MINGW64_BIN}/gcc.exe" )
+  set(CMAKE_CXX_COMPILER  "$ENV{MINGW64_BIN}/g++.exe" )
+else()
+  set(CMAKE_C_COMPILER    gcc )
+  set(CMAKE_CXX_COMPILER  g++ )
+endif()
+
+## Linking statically keeps the test executables free of libstdc++ and libwinpthread, which live beside
+## the compiler and would otherwise have to be on PATH for every step that runs a test.
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-static")

--- a/test/toolchain/setup_mingw64.sh
+++ b/test/toolchain/setup_mingw64.sh
@@ -13,18 +13,20 @@ for candidate in "${MINGW64_BIN}"                                               
                  "/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin"  \
                  "/c/mingw64/bin"
 do
-  if [ -n "$candidate" ] && [ -x "$candidate/g++.exe" ]; then
+  if [[ -n "$candidate" && -x "$candidate/g++.exe" ]]; then
     mingw_bin="$candidate"
     break
   fi
 done
 
-if [ -z "$mingw_bin" ]; then
-  probe="$(command -v g++ 2>/dev/null)"
-  [ -n "$probe" ] && mingw_bin="$(dirname "$probe")"
+if [[ -z "$mingw_bin" ]]; then
+  probe="$(command -v g++ 2>/dev/null || true)"
+  if [[ -n "$probe" ]]; then
+    mingw_bin="$(dirname "$probe")"
+  fi
 fi
 
-if [ -z "$mingw_bin" ]; then
+if [[ -z "$mingw_bin" ]]; then
   echo "No MinGW g++ found. Looked in /c/msys64/mingw64/bin," \
        "/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin, /c/mingw64/bin and PATH." >&2
   return 1 2>/dev/null || exit 1
@@ -43,6 +45,8 @@ esac
 
 ## CMake reads this one, and the following steps of the job get the directory through GITHUB_PATH.
 export MINGW64_BIN="$(cygpath -m "$mingw_bin" 2>/dev/null || echo "$mingw_bin")"
-[ -n "$GITHUB_PATH" ] && echo "$MINGW64_BIN" >> "$GITHUB_PATH"
+if [[ -n "$GITHUB_PATH" ]]; then
+  echo "$MINGW64_BIN" >> "$GITHUB_PATH"
+fi
 
 echo "Using $(g++ --version | head -1) from $MINGW64_BIN"

--- a/test/toolchain/setup_mingw64.sh
+++ b/test/toolchain/setup_mingw64.sh
@@ -1,0 +1,48 @@
+##======================================================================================================================
+##  SPY - C++ Informations Broker
+##  Copyright : SPY Project Contributors
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Sourced by the matrix before configuring the mingw64 row. The Windows runner ships a MinGW-w64 g++ but leaves it
+## out of PATH, and where it lives has moved between image versions, so the directory is looked up rather than named.
+##======================================================================================================================
+mingw_bin=""
+
+for candidate in "${MINGW64_BIN}"                                                 \
+                 "/c/msys64/mingw64/bin"                                          \
+                 "/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin"  \
+                 "/c/mingw64/bin"
+do
+  if [ -n "$candidate" ] && [ -x "$candidate/g++.exe" ]; then
+    mingw_bin="$candidate"
+    break
+  fi
+done
+
+if [ -z "$mingw_bin" ]; then
+  probe="$(command -v g++ 2>/dev/null)"
+  [ -n "$probe" ] && mingw_bin="$(dirname "$probe")"
+fi
+
+if [ -z "$mingw_bin" ]; then
+  echo "No MinGW g++ found. Looked in /c/msys64/mingw64/bin," \
+       "/c/ProgramData/chocolatey/lib/mingw/tools/install/mingw64/bin, /c/mingw64/bin and PATH." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+export PATH="$mingw_bin:$PATH"
+
+## A g++ that is not a MinGW one would build a target spy reports as something else, so the failure is made loud here
+## rather than left to a unit test on another platform.
+target="$(g++ -dumpmachine)"
+case "$target" in
+  *mingw*) ;;
+  *) echo "g++ in $mingw_bin targets $target, which is not MinGW." >&2
+     return 1 2>/dev/null || exit 1 ;;
+esac
+
+## CMake reads this one, and the following steps of the job get the directory through GITHUB_PATH.
+export MINGW64_BIN="$(cygpath -m "$mingw_bin" 2>/dev/null || echo "$mingw_bin")"
+[ -n "$GITHUB_PATH" ] && echo "$MINGW64_BIN" >> "$GITHUB_PATH"
+
+echo "Using $(g++ --version | head -1) from $MINGW64_BIN"


### PR DESCRIPTION
The Windows runner ships a MinGW-w64 g++ but keeps it out of PATH, and its directory has moved
between image versions. The row sources a script that looks it up in the three known places, falls
back to whatever `command -v` finds, and refuses any g++ whose `-dumpmachine` is not a MinGW target
rather than quietly building for another one.

Test executables are linked statically: the setup script is sourced by the build step alone, and the
step running ctest has a shell of its own, where a dynamically linked executable would look for
`libstdc++-6.dll` and not find it. The image carries no i686 toolchain, so this row exercises
`spy::mingw64_` and leaves `spy::mingw32_` uncovered.
