### PR TITLE
Move to copacabana v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   ##################################################################################################
   precommit:
     name: Meta Checks
-    uses: jfalcou/copacabana/.github/workflows/precommit.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/precommit.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
 
   ##======================================================================================================================
   ## Ensure Standalone is viable
@@ -49,14 +49,14 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
-    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
 
   ##################################################################################################
   ## Coverage report - informational, runs alongside the gate without blocking the matrix
   ##################################################################################################
   coverage-report:
     name: Coverage
-    uses: jfalcou/copacabana/.github/workflows/coverage.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/coverage.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: spy
 
@@ -66,27 +66,27 @@ jobs:
   linux-tests:
     name: Linux
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/linux.yml
 
   macos-tests:
     name: MacOS
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/macos.yml
 
   windows-tests:
     name: Windows
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/windows.yml
 
   nvidia-tests:
     name: Nvidia
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/nvidia.yml

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: spy
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: spy
       cxx-compiler: clang++

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: spy

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -12,4 +12,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v7)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v8)

--- a/test/assert.hpp
+++ b/test/assert.hpp
@@ -37,4 +37,6 @@ namespace spy
   }
 }
 
-#define SPY_ASSERT(MESSAGE, ...) spy::check<(__VA_ARGS__)>(MESSAGE, #__VA_ARGS__)
+// static_cast, because what spy reports is an object with an explicit operator bool, which a bool
+// template argument does not convert on its own.
+#define SPY_ASSERT(MESSAGE, ...) spy::check<static_cast<bool>(__VA_ARGS__)>(MESSAGE, #__VA_ARGS__)

--- a/test/assert.hpp
+++ b/test/assert.hpp
@@ -1,0 +1,40 @@
+//======================================================================================================================
+/**
+  SPY - C++ Informations Broker
+  Copyright : SPY Project Contributors
+  SPDX-License-Identifier: BSL-1.0
+**/
+//======================================================================================================================
+#pragma once
+
+#include <cstdlib>
+#include <iostream>
+
+namespace spy
+{
+  //====================================================================================================================
+  // Everything spy reports is known at compile time, so the condition is a template argument: a
+  // check that is not a constant expression does not compile, and the failing branch is chosen by
+  // if constexpr rather than at run time.
+  //
+  // Unlike assert, this one holds under NDEBUG, which is what the Release half of the matrix
+  // compiles with, and it is named check because assert is a macro of <cassert> that no header here
+  // can be sure nobody pulled in.
+  //====================================================================================================================
+  template<bool Condition> void check(char const* message, char const* expression)
+  {
+    std::cout << message << ": ";
+
+    if constexpr(Condition)
+    {
+      std::cout << "OK" << std::endl;
+    }
+    else
+    {
+      std::cout << "ERROR : " << expression << std::endl;
+      std::abort();
+    }
+  }
+}
+
+#define SPY_ASSERT(MESSAGE, ...) spy::check<(__VA_ARGS__)>(MESSAGE, #__VA_ARGS__)

--- a/test/unit/accelerator.cpp
+++ b/test/unit/accelerator.cpp
@@ -31,5 +31,4 @@ int main(
     std::cout << "Currently compiling without CUDA enabled\n";
 #endif
   }
-  std::cout << "Done." << std::endl;
 }

--- a/test/unit/accelerator.cpp
+++ b/test/unit/accelerator.cpp
@@ -8,27 +8,25 @@
 #include <iostream>
 #include <spy/spy.hpp>
 
-int main(
+#include "assert.hpp"
 
-)
+int main()
 {
-  std::cout << "Check that specified accelerator is supported: " << std::endl;
+  std::cout << "== specified accelerator is supported\n";
   {
 #if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
-    static_assert(spy::supports::sycl);
-    std::cout << "Currently compiling with " << spy::supports::sycl << " enabled\n";
+    SPY_ASSERT("sycl is reported", spy::supports::sycl);
+    std::cout << "Compiled with " << spy::supports::sycl << "\n";
 #else
-    static_assert(!spy::supports::sycl);
-    std::cout << "Currently compiling without SYCL enabled\n";
+    SPY_ASSERT("sycl is not reported", !spy::supports::sycl);
 #endif
   }
   {
 #if defined(__NVCC__) && defined(__CUDACC__)
-    static_assert(spy::supports::cuda);
-    std::cout << "Currently compiling with " << spy::supports::cuda << " enabled\n";
+    SPY_ASSERT("cuda is reported", spy::supports::cuda);
+    std::cout << "Compiled with " << spy::supports::cuda << "\n";
 #else
-    static_assert(!spy::supports::cuda);
-    std::cout << "Currently compiling without CUDA enabled\n";
+    SPY_ASSERT("cuda is not reported", !spy::supports::cuda);
 #endif
   }
 }

--- a/test/unit/accelerator.cu
+++ b/test/unit/accelerator.cu
@@ -6,6 +6,7 @@
 **/
 //==================================================================================================
 #include <spy/spy.hpp>
+
 #include <iostream>
 
 int main()
@@ -13,21 +14,20 @@ int main()
   std::cout << "Check that specified accelerator is supported: " << std::endl;
   {
     #if defined(SYCL_LANGUAGE_VERSION) && defined (__INTEL_LLVM_COMPILER)
-    static_assert( spy::supports::sycl );
+    static_assert(spy::supports::sycl);
     std::cout << "Currently compiling with " << spy::supports::sycl << " enabled\n";
     #else
-    static_assert( !spy::supports::sycl );
+    static_assert(!spy::supports::sycl);
     std::cout << "Currently compiling without SYCL enabled\n";
     #endif
   }
   {
     #if defined (__CUDACC__)
-    static_assert( spy::supports::cuda );
+    static_assert(spy::supports::cuda);
     std::cout << "Currently compiling with " << spy::supports::cuda << " enabled\n";
     #else
-    static_assert( !spy::supports::cuda );
+    static_assert(!spy::supports::cuda);
     std::cout << "Currently compiling without CUDA enabled\n";
     #endif
   }
-  std::cout << "Done." << std::endl;
 }

--- a/test/unit/accelerator.cu
+++ b/test/unit/accelerator.cu
@@ -9,25 +9,25 @@
 
 #include <iostream>
 
+#include "assert.hpp"
+
 int main()
 {
-  std::cout << "Check that specified accelerator is supported: " << std::endl;
+  std::cout << "== specified accelerator is supported\n";
   {
     #if defined(SYCL_LANGUAGE_VERSION) && defined (__INTEL_LLVM_COMPILER)
-    static_assert(spy::supports::sycl);
-    std::cout << "Currently compiling with " << spy::supports::sycl << " enabled\n";
+    SPY_ASSERT("sycl is reported", spy::supports::sycl);
+    std::cout << "Compiled with " << spy::supports::sycl << "\n";
     #else
-    static_assert(!spy::supports::sycl);
-    std::cout << "Currently compiling without SYCL enabled\n";
+    SPY_ASSERT("sycl is not reported", !spy::supports::sycl);
     #endif
   }
   {
     #if defined (__CUDACC__)
-    static_assert(spy::supports::cuda);
-    std::cout << "Currently compiling with " << spy::supports::cuda << " enabled\n";
+    SPY_ASSERT("cuda is reported", spy::supports::cuda);
+    std::cout << "Compiled with " << spy::supports::cuda << "\n";
     #else
-    static_assert(!spy::supports::cuda);
-    std::cout << "Currently compiling without CUDA enabled\n";
+    SPY_ASSERT("cuda is not reported", !spy::supports::cuda);
     #endif
   }
 }

--- a/test/unit/arch.cpp
+++ b/test/unit/arch.cpp
@@ -5,9 +5,10 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
+
+#include "assert.hpp"
 
 int main()
 {
@@ -16,58 +17,58 @@ int main()
 #if defined(i386) || defined(__i386__) || defined(__i486__) || defined(__i586__) ||                \
     defined(__i686__) || defined(__i386) || defined(_M_IX86) || defined(_X86_) ||                  \
     defined(__THW_INTEL__) || defined(__I86__) || defined(__INTEL__)
-    assert(spy::architecture == spy::x86_);
-    assert(!(spy::architecture == spy::amd64_));
-    assert(!(spy::architecture == spy::ppc_));
-    assert(!(spy::architecture == spy::arm_));
-    assert(!(spy::architecture == spy::wasm_));
-    assert(!(spy::architecture == spy::riscv_));
+    SPY_ASSERT("the architecture is x86", spy::architecture == spy::x86_);
+    SPY_ASSERT("the architecture is not amd64", !(spy::architecture == spy::amd64_));
+    SPY_ASSERT("the architecture is not ppc", !(spy::architecture == spy::ppc_));
+    SPY_ASSERT("the architecture is not arm", !(spy::architecture == spy::arm_));
+    SPY_ASSERT("the architecture is not wasm", !(spy::architecture == spy::wasm_));
+    SPY_ASSERT("the architecture is not riscv", !(spy::architecture == spy::riscv_));
 #elif defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__amd64) ||        \
     defined(_M_X64)
-    assert(!(spy::architecture == spy::x86_));
-    assert(spy::architecture == spy::amd64_);
-    assert(!(spy::architecture == spy::ppc_));
-    assert(!(spy::architecture == spy::arm_));
-    assert(!(spy::architecture == spy::wasm_));
-    assert(!(spy::architecture == spy::riscv_));
+    SPY_ASSERT("the architecture is not x86", !(spy::architecture == spy::x86_));
+    SPY_ASSERT("the architecture is amd64", spy::architecture == spy::amd64_);
+    SPY_ASSERT("the architecture is not ppc", !(spy::architecture == spy::ppc_));
+    SPY_ASSERT("the architecture is not arm", !(spy::architecture == spy::arm_));
+    SPY_ASSERT("the architecture is not wasm", !(spy::architecture == spy::wasm_));
+    SPY_ASSERT("the architecture is not riscv", !(spy::architecture == spy::riscv_));
 #elif defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) || defined(__ppc__) ||    \
     defined(_M_PPC) || defined(_ARCH_PPC) || defined(__PPCGECKO__) || defined(__PPCBROADWAY__) ||  \
     defined(_XENON)
-    assert(!(spy::architecture == spy::x86_));
-    assert(!(spy::architecture == spy::amd64_));
-    assert(spy::architecture == spy::ppc_);
-    assert(!(spy::architecture == spy::arm_));
-    assert(!(spy::architecture == spy::wasm_));
-    assert(!(spy::architecture == spy::riscv_));
+    SPY_ASSERT("the architecture is not x86", !(spy::architecture == spy::x86_));
+    SPY_ASSERT("the architecture is not amd64", !(spy::architecture == spy::amd64_));
+    SPY_ASSERT("the architecture is ppc", spy::architecture == spy::ppc_);
+    SPY_ASSERT("the architecture is not arm", !(spy::architecture == spy::arm_));
+    SPY_ASSERT("the architecture is not wasm", !(spy::architecture == spy::wasm_));
+    SPY_ASSERT("the architecture is not riscv", !(spy::architecture == spy::riscv_));
 #elif defined(__arm__) || defined(__arm64) || defined(__thumb__) || defined(__TARGET_ARCH_ARM) ||  \
     defined(__TARGET_ARCH_THUMB) || defined(_M_ARM) || defined(__ARM_ARCH_ISA_A64)
-    assert(!(spy::architecture == spy::x86_));
-    assert(!(spy::architecture == spy::amd64_));
-    assert(!(spy::architecture == spy::ppc_));
-    assert(spy::architecture == spy::arm_);
-    assert(!(spy::architecture == spy::wasm_));
-    assert(!(spy::architecture == spy::riscv_));
+    SPY_ASSERT("the architecture is not x86", !(spy::architecture == spy::x86_));
+    SPY_ASSERT("the architecture is not amd64", !(spy::architecture == spy::amd64_));
+    SPY_ASSERT("the architecture is not ppc", !(spy::architecture == spy::ppc_));
+    SPY_ASSERT("the architecture is arm", spy::architecture == spy::arm_);
+    SPY_ASSERT("the architecture is not wasm", !(spy::architecture == spy::wasm_));
+    SPY_ASSERT("the architecture is not riscv", !(spy::architecture == spy::riscv_));
 #elif defined(__wasm__)
-    assert(!(spy::architecture == spy::x86_));
-    assert(!(spy::architecture == spy::amd64_));
-    assert(!(spy::architecture == spy::ppc_));
-    assert(!(spy::architecture == spy::arm_));
-    assert(spy::architecture == spy::wasm_);
-    assert(!(spy::architecture == spy::riscv_));
+    SPY_ASSERT("the architecture is not x86", !(spy::architecture == spy::x86_));
+    SPY_ASSERT("the architecture is not amd64", !(spy::architecture == spy::amd64_));
+    SPY_ASSERT("the architecture is not ppc", !(spy::architecture == spy::ppc_));
+    SPY_ASSERT("the architecture is not arm", !(spy::architecture == spy::arm_));
+    SPY_ASSERT("the architecture is wasm", spy::architecture == spy::wasm_);
+    SPY_ASSERT("the architecture is not riscv", !(spy::architecture == spy::riscv_));
 #elif defined(__riscv)
-    assert(!(spy::architecture == spy::x86_));
-    assert(!(spy::architecture == spy::amd64_));
-    assert(!(spy::architecture == spy::ppc_));
-    assert(!(spy::architecture == spy::arm_));
-    assert(!(spy::architecture == spy::wasm_));
-    assert(spy::architecture == spy::riscv_);
+    SPY_ASSERT("the architecture is not x86", !(spy::architecture == spy::x86_));
+    SPY_ASSERT("the architecture is not amd64", !(spy::architecture == spy::amd64_));
+    SPY_ASSERT("the architecture is not ppc", !(spy::architecture == spy::ppc_));
+    SPY_ASSERT("the architecture is not arm", !(spy::architecture == spy::arm_));
+    SPY_ASSERT("the architecture is not wasm", !(spy::architecture == spy::wasm_));
+    SPY_ASSERT("the architecture is riscv", spy::architecture == spy::riscv_);
 #else
-    assert(!(spy::architecture == spy::x86_));
-    assert(!(spy::architecture == spy::amd64_));
-    assert(!(spy::architecture == spy::ppc_));
-    assert(!(spy::architecture == spy::arm_));
-    assert(!(spy::architecture == spy::wasm_));
-    assert(!(spy::architecture == spy::riscv_));
+    SPY_ASSERT("the architecture is not x86", !(spy::architecture == spy::x86_));
+    SPY_ASSERT("the architecture is not amd64", !(spy::architecture == spy::amd64_));
+    SPY_ASSERT("the architecture is not ppc", !(spy::architecture == spy::ppc_));
+    SPY_ASSERT("the architecture is not arm", !(spy::architecture == spy::arm_));
+    SPY_ASSERT("the architecture is not wasm", !(spy::architecture == spy::wasm_));
+    SPY_ASSERT("the architecture is not riscv", !(spy::architecture == spy::riscv_));
 #endif
 
     std::cout << "X86    status: " << std::boolalpha << (spy::architecture == spy::x86_)
@@ -83,5 +84,4 @@ int main()
     std::cout << "RISC-V status: " << std::boolalpha << (spy::architecture == spy::riscv_)
               << std::endl;
   }
-  std::cout << "Done." << std::endl;
 }

--- a/test/unit/compiler.cpp
+++ b/test/unit/compiler.cpp
@@ -5,242 +5,240 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
 
+#include "assert.hpp"
+
 int main()
 {
-  std::cout << "Check that detected compiler is correct: " << std::flush;
+  std::cout << "== detected compiler is correct\n";
   {
 #if defined(__NVCC__)
-    assert(spy::compiler == spy::nvcc_);
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is nvcc", spy::compiler == spy::nvcc_);
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(__MINGW32__) && !defined(__MINGW64__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(spy::compiler == spy::mingw32_);
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is mingw32", spy::compiler == spy::mingw32_);
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(__MINGW32__) && defined(__MINGW64__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(spy::compiler == spy::mingw64_);
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is mingw64", spy::compiler == spy::mingw64_);
 #elif defined(_MSC_VER) && !defined(__clang__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(spy::compiler == spy::msvc_);
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is msvc", spy::compiler == spy::msvc_);
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(_MSC_VER) && defined(__clang__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(spy::compiler == spy::clangcl_);
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is clang-cl", spy::compiler == spy::clangcl_);
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(spy::compiler == spy::intel_);
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is icc", spy::compiler == spy::intel_);
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(__INTEL_LLVM_COMPILER)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(spy::compiler == spy::dpcpp_);
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is dpc++", spy::compiler == spy::dpcpp_);
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(__EMSCRIPTEN__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(!(spy::compiler == spy::gcc_));
-    assert(spy::compiler == spy::emscripten_);
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is emscripten", spy::compiler == spy::emscripten_);
 #elif defined(__clang__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(spy::compiler == spy::clang_);
-    assert(!(spy::compiler == spy::gcc_));
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is clang", spy::compiler == spy::clang_);
+    SPY_ASSERT("the compiler is not g++", !(spy::compiler == spy::gcc_));
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #elif defined(__GNUC__)
-    assert(!(spy::compiler == spy::nvcc_));
-    assert(!(spy::compiler == spy::msvc_));
-    assert(!(spy::compiler == spy::clangcl_));
-    assert(!(spy::compiler == spy::intel_));
-    assert(!(spy::compiler == spy::dpcpp_));
-    assert(!(spy::compiler == spy::clang_));
-    assert(spy::compiler == spy::gcc_);
-    assert(!(spy::compiler == spy::emscripten_));
-    assert(!(spy::compiler == spy::mingw32_));
-    assert(!(spy::compiler == spy::mingw64_));
+    SPY_ASSERT("the compiler is not nvcc", !(spy::compiler == spy::nvcc_));
+    SPY_ASSERT("the compiler is not msvc", !(spy::compiler == spy::msvc_));
+    SPY_ASSERT("the compiler is not clang-cl", !(spy::compiler == spy::clangcl_));
+    SPY_ASSERT("the compiler is not icc", !(spy::compiler == spy::intel_));
+    SPY_ASSERT("the compiler is not dpc++", !(spy::compiler == spy::dpcpp_));
+    SPY_ASSERT("the compiler is not clang", !(spy::compiler == spy::clang_));
+    SPY_ASSERT("the compiler is g++", spy::compiler == spy::gcc_);
+    SPY_ASSERT("the compiler is not emscripten", !(spy::compiler == spy::emscripten_));
+    SPY_ASSERT("the compiler is not mingw32", !(spy::compiler == spy::mingw32_));
+    SPY_ASSERT("the compiler is not mingw64", !(spy::compiler == spy::mingw64_));
 #endif
   }
-  std::cout << "Done." << std::endl;
   std::cout << "Detected compiler: " << spy::compiler << std::endl;
 
-  std::cout << "Check that detected compiler version is correct: " << std::flush;
+  std::cout << "== detected compiler version is correct\n";
   {
     using namespace spy::literal;
 
 #if defined(__NVCC__)
-    assert(spy::compiler >= 6'0_nvcc);
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is at least nvcc 6.0", spy::compiler >= 6'0_nvcc);
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(_MSC_VER) && !defined(__clang__)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(spy::compiler >= 19'5_msvc);
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is at least msvc 19.5", spy::compiler >= 19'5_msvc);
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(_MSC_VER) && !defined(__clang__)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(spy::compiler >= 3'9_clangcl);
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is at least clang-cl 3.9", spy::compiler >= 3'9_clangcl);
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(spy::compiler >= 19_intel);
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is at least icc 19", spy::compiler >= 19_intel);
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(__INTEL_LLVM_COMPILER)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(spy::compiler >= 2023'1_dpcpp);
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is at least dpc++ 2023.1", spy::compiler >= 2023'1_dpcpp);
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(__EMSCRIPTEN__)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(spy::compiler >= 3'1_em);
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is at least emscripten 3.1", spy::compiler >= 3'1_em);
 #elif defined(__clang__) && !defined(_MSC_VER)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(spy::compiler >= 3'9_clang);
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is at least clang 3.9", spy::compiler >= 3'9_clang);
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(__MINGW32__) && !defined(__MINGW64__)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(spy::compiler >= 15'2_mingw32);
-    assert(!(spy::compiler >= 15'2_mingw64));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is at least mingw32 7.2", spy::compiler >= 7'2_mingw32);
+    SPY_ASSERT("the version is under mingw64 7.2", !(spy::compiler >= 7'2_mingw64));
 #elif defined(__MINGW32__) && defined(__MINGW64__)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(!(spy::compiler >= 7'2_gcc));
-    assert(!(spy::compiler >= 3'1_em));
-    assert(!(spy::compiler >= 15'2_mingw32));
-    assert(spy::compiler >= 15'2_mingw64);
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is under g++ 7.2", !(spy::compiler >= 7'2_gcc));
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under mingw32 7.2", !(spy::compiler >= 7'2_mingw32));
+    SPY_ASSERT("the version is at least mingw64 7.2", spy::compiler >= 7'2_mingw64);
 #elif defined(__GNUC__)
-    assert(!(spy::compiler >= 6'0_nvcc));
-    assert(!(spy::compiler >= 19'5_msvc));
-    assert(!(spy::compiler >= 3'9_clangcl));
-    assert(!(spy::compiler >= 19_intel));
-    assert(!(spy::compiler >= 2023'1_dpcpp));
-    assert(!(spy::compiler >= 3'9_clang));
-    assert(spy::compiler >= 7'2_gcc);
-    assert(!(spy::compiler >= 3'1_em));
+    SPY_ASSERT("the version is under nvcc 6.0", !(spy::compiler >= 6'0_nvcc));
+    SPY_ASSERT("the version is under msvc 19.5", !(spy::compiler >= 19'5_msvc));
+    SPY_ASSERT("the version is under clang-cl 3.9", !(spy::compiler >= 3'9_clangcl));
+    SPY_ASSERT("the version is under icc 19", !(spy::compiler >= 19_intel));
+    SPY_ASSERT("the version is under dpc++ 2023.1", !(spy::compiler >= 2023'1_dpcpp));
+    SPY_ASSERT("the version is under clang 3.9", !(spy::compiler >= 3'9_clang));
+    SPY_ASSERT("the version is at least g++ 7.2", spy::compiler >= 7'2_gcc);
+    SPY_ASSERT("the version is under emscripten 3.1", !(spy::compiler >= 3'1_em));
 #endif
   }
-  std::cout << "Done." << std::endl;
 
-  std::cout << "Check that detected constexpr selection on exact compiler is correct: "
-            << std::flush;
+  std::cout << "== detected constexpr selection on exact compiler is correct\n";
   {
     using namespace spy::literal;
 
@@ -266,12 +264,11 @@ int main()
 
     if constexpr(spy::compiler)
     {
-      assert(!bool(wrong_constexpr_behavior));
+      SPY_ASSERT("a version that does not match is turned down", !bool(wrong_constexpr_behavior));
     }
     else
     {
-      assert(bool(wrong_constexpr_behavior));
+      SPY_ASSERT("a version that does not match selects nothing", bool(wrong_constexpr_behavior));
     }
   }
-  std::cout << "Done." << std::endl;
 }

--- a/test/unit/data_model.cpp
+++ b/test/unit/data_model.cpp
@@ -5,30 +5,31 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
+
+#include "assert.hpp"
 
 int main()
 {
   std::cout << "Check that detected data model is correct: " << std::endl;
   {
 #if defined(__LP64__) || defined(_LP64)
-    assert(!(spy::data_model == spy::ilp32_));
-    assert(!(spy::data_model == spy::lp32_));
-    assert(!(spy::data_model == spy::silp64_));
-    assert(!(spy::data_model == spy::ilp64_));
-    assert(!(spy::data_model == spy::llp64_));
-    assert(spy::data_model == spy::lp64_);
+    SPY_ASSERT("the data model is not ilp32", !(spy::data_model == spy::ilp32_));
+    SPY_ASSERT("the data model is not lp32", !(spy::data_model == spy::lp32_));
+    SPY_ASSERT("the data model is not silp64", !(spy::data_model == spy::silp64_));
+    SPY_ASSERT("the data model is not ilp64", !(spy::data_model == spy::ilp64_));
+    SPY_ASSERT("the data model is not llp64", !(spy::data_model == spy::llp64_));
+    SPY_ASSERT("the data model is lp64", spy::data_model == spy::lp64_);
 #endif
 
 #if defined(__ILP32__) || defined(_ILP32)
-    assert(spy::data_model == spy::ilp32_);
-    assert(!(spy::data_model == spy::lp32_));
-    assert(!(spy::data_model == spy::silp64_));
-    assert(!(spy::data_model == spy::ilp64_));
-    assert(!(spy::data_model == spy::llp64_));
-    assert(!(spy::data_model == spy::lp64_));
+    SPY_ASSERT("the data model is ilp32", spy::data_model == spy::ilp32_);
+    SPY_ASSERT("the data model is not lp32", !(spy::data_model == spy::lp32_));
+    SPY_ASSERT("the data model is not silp64", !(spy::data_model == spy::silp64_));
+    SPY_ASSERT("the data model is not ilp64", !(spy::data_model == spy::ilp64_));
+    SPY_ASSERT("the data model is not llp64", !(spy::data_model == spy::llp64_));
+    SPY_ASSERT("the data model is not lp64", !(spy::data_model == spy::lp64_));
 #endif
 
     std::cout << "ILP32  status: " << std::boolalpha << (spy::data_model == spy::ilp32_)
@@ -44,6 +45,5 @@ int main()
     std::cout << "LP64   status: " << std::boolalpha << (spy::data_model == spy::lp64_)
               << std::endl;
   }
-  std::cout << "Done." << std::endl;
   std::cout << "Data model detected: " << spy::data_model << std::endl;
 }

--- a/test/unit/libc.cpp
+++ b/test/unit/libc.cpp
@@ -5,56 +5,56 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
 
+#include "assert.hpp"
+
 int main()
 {
-  std::cout << "Check that detected libc is correct: " << std::flush;
+  std::cout << "== detected libc is correct\n";
   {
 #if defined(__cloudlibc__)
-    assert(spy::libc == spy::cloudabi_);
-    assert(!(spy::libc == spy::uc_));
-    assert(!(spy::libc == spy::vms_));
-    assert(!(spy::libc == spy::zos_));
-    assert(!(spy::libc == spy::gnu_));
+    SPY_ASSERT("the libc is cloudabi", spy::libc == spy::cloudabi_);
+    SPY_ASSERT("the libc is not uClibc", !(spy::libc == spy::uc_));
+    SPY_ASSERT("the libc is not vms", !(spy::libc == spy::vms_));
+    SPY_ASSERT("the libc is not z/OS", !(spy::libc == spy::zos_));
+    SPY_ASSERT("the libc is not glibc", !(spy::libc == spy::gnu_));
 #elif defined(__UCLIBC__)
-    assert(!(spy::libc == spy::cloudabi_));
-    assert(spy::libc == spy::uc_);
-    assert(!(spy::libc == spy::vms_));
-    assert(!(spy::libc == spy::zos_));
-    assert(!(spy::libc == spy::gnu_));
+    SPY_ASSERT("the libc is not cloudabi", !(spy::libc == spy::cloudabi_));
+    SPY_ASSERT("the libc is uClibc", spy::libc == spy::uc_);
+    SPY_ASSERT("the libc is not vms", !(spy::libc == spy::vms_));
+    SPY_ASSERT("the libc is not z/OS", !(spy::libc == spy::zos_));
+    SPY_ASSERT("the libc is not glibc", !(spy::libc == spy::gnu_));
 #elif defined(__CRTL_VER)
-    assert(!(spy::libc == spy::cloudabi_));
-    assert(!(spy::libc == spy::uc_));
-    assert(spy::libc == spy::vms_);
-    assert(!(spy::libc == spy::zos_));
-    assert(!(spy::libc == spy::gnu_));
+    SPY_ASSERT("the libc is not cloudabi", !(spy::libc == spy::cloudabi_));
+    SPY_ASSERT("the libc is not uClibc", !(spy::libc == spy::uc_));
+    SPY_ASSERT("the libc is vms", spy::libc == spy::vms_);
+    SPY_ASSERT("the libc is not z/OS", !(spy::libc == spy::zos_));
+    SPY_ASSERT("the libc is not glibc", !(spy::libc == spy::gnu_));
 #elif defined(__LIBREL__)
-    assert(!(spy::libc == spy::cloudabi_));
-    assert(!(spy::libc == spy::uc_));
-    assert(!(spy::libc == spy::vms_));
-    assert(spy::libc == spy::zos_);
-    assert(!(spy::libc == spy::gnu_));
+    SPY_ASSERT("the libc is not cloudabi", !(spy::libc == spy::cloudabi_));
+    SPY_ASSERT("the libc is not uClibc", !(spy::libc == spy::uc_));
+    SPY_ASSERT("the libc is not vms", !(spy::libc == spy::vms_));
+    SPY_ASSERT("the libc is z/OS", spy::libc == spy::zos_);
+    SPY_ASSERT("the libc is not glibc", !(spy::libc == spy::gnu_));
 #elif defined(__GLIBC__) || defined(__GNU_LIBRARY__)
-    assert(!(spy::libc == spy::cloudabi_));
-    assert(!(spy::libc == spy::uc_));
-    assert(!(spy::libc == spy::vms_));
-    assert(!(spy::libc == spy::zos_));
-    assert(spy::libc == spy::gnu_);
+    SPY_ASSERT("the libc is not cloudabi", !(spy::libc == spy::cloudabi_));
+    SPY_ASSERT("the libc is not uClibc", !(spy::libc == spy::uc_));
+    SPY_ASSERT("the libc is not vms", !(spy::libc == spy::vms_));
+    SPY_ASSERT("the libc is not z/OS", !(spy::libc == spy::zos_));
+    SPY_ASSERT("the libc is glibc", spy::libc == spy::gnu_);
 #else
-    assert(!(spy::libc == spy::cloudabi_));
-    assert(!(spy::libc == spy::uc_));
-    assert(!(spy::libc == spy::vms_));
-    assert(!(spy::libc == spy::zos_));
-    assert(!(spy::libc == spy::gnu_));
+    SPY_ASSERT("the libc is not cloudabi", !(spy::libc == spy::cloudabi_));
+    SPY_ASSERT("the libc is not uClibc", !(spy::libc == spy::uc_));
+    SPY_ASSERT("the libc is not vms", !(spy::libc == spy::vms_));
+    SPY_ASSERT("the libc is not z/OS", !(spy::libc == spy::zos_));
+    SPY_ASSERT("the libc is not glibc", !(spy::libc == spy::gnu_));
 #endif
   }
-  std::cout << "Done." << std::endl;
   std::cout << "Detected libc: " << spy::libc << std::endl;
 
-  std::cout << "Check that detected constexpr selection on exact libc is correct: " << std::flush;
+  std::cout << "== detected constexpr selection on exact libc is correct\n";
   {
     using namespace spy::literal;
 
@@ -74,12 +74,11 @@ int main()
 
     if constexpr(spy::libc)
     {
-      assert(!bool(wrong_constexpr_behavior));
+      SPY_ASSERT("a version that does not match is turned down", !bool(wrong_constexpr_behavior));
     }
     else
     {
-      assert(bool(wrong_constexpr_behavior));
+      SPY_ASSERT("a version that does not match selects nothing", bool(wrong_constexpr_behavior));
     }
   }
-  std::cout << "Done." << std::endl;
 }

--- a/test/unit/os.cpp
+++ b/test/unit/os.cpp
@@ -5,90 +5,90 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
 
+#include "assert.hpp"
+
 int main()
 {
-  std::cout << "Check that detected OS is correct: " << std::flush;
+  std::cout << "== detected OS is correct\n";
   {
 #if defined(__ANDROID__)
-    assert(spy::operating_system == spy::android_);
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(!(spy::operating_system == spy::ios_));
-    assert(!(spy::operating_system == spy::linux_));
-    assert(!(spy::operating_system == spy::macos_));
-    assert(!(spy::operating_system == spy::unix_));
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is android", spy::operating_system == spy::android_);
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(BSD) || defined(_SYSTYPE_BSD)
-    assert(!(spy::operating_system == spy::android_));
-    assert(spy::operating_system == spy::bsd_);
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(!(spy::operating_system == spy::ios_));
-    assert(!(spy::operating_system == spy::linux_));
-    assert(!(spy::operating_system == spy::macos_));
-    assert(!(spy::operating_system == spy::unix_));
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is bsd", spy::operating_system == spy::bsd_);
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(__CYGWIN__)
-    assert(!(spy::operating_system == spy::android_));
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(spy::operating_system == spy::cygwin_);
-    assert(!(spy::operating_system == spy::ios_));
-    assert(!(spy::operating_system == spy::linux_));
-    assert(!(spy::operating_system == spy::macos_));
-    assert(!(spy::operating_system == spy::unix_));
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is cygwin", spy::operating_system == spy::cygwin_);
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(__APPLE__) && defined(__MACH__) &&                                                   \
     defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__)
-    assert(!(spy::operating_system == spy::android_));
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(spy::operating_system == spy::ios_);
-    assert(!(spy::operating_system == spy::linux_));
-    assert(!(spy::operating_system == spy::macos_));
-    assert(!(spy::operating_system == spy::unix_));
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is ios", spy::operating_system == spy::ios_);
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(linux) || defined(__linux)
-    assert(!(spy::operating_system == spy::android_));
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(!(spy::operating_system == spy::ios_));
-    assert(spy::operating_system == spy::linux_);
-    assert(!(spy::operating_system == spy::macos_));
-    assert(!(spy::operating_system == spy::unix_));
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is linux", spy::operating_system == spy::linux_);
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(macintosh) || defined(Macintosh) || (defined(__APPLE__) && defined(__MACH__))
-    assert(!(spy::operating_system == spy::android_));
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(!(spy::operating_system == spy::ios_));
-    assert(!(spy::operating_system == spy::linux_));
-    assert(spy::operating_system == spy::macos_);
-    assert(!(spy::operating_system == spy::unix_));
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is macos", spy::operating_system == spy::macos_);
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(unix) || defined(__unix) || defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE)
-    assert(!(spy::operating_system == spy::android_));
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(!(spy::operating_system == spy::ios_));
-    assert(!(spy::operating_system == spy::linux_));
-    assert(!(spy::operating_system == spy::macos_));
-    assert(spy::operating_system == spy::unix_);
-    assert(!(spy::operating_system == spy::windows_));
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is unix", spy::operating_system == spy::unix_);
+    SPY_ASSERT("the system is not windows", !(spy::operating_system == spy::windows_));
 #elif defined(_WIN32) || defined(_WIN64) || defined(__WIN32__) || defined(__TOS_WIN__) ||          \
     defined(__WINDOWS__)
-    assert(!(spy::operating_system == spy::android_));
-    assert(!(spy::operating_system == spy::bsd_));
-    assert(!(spy::operating_system == spy::cygwin_));
-    assert(!(spy::operating_system == spy::ios_));
-    assert(!(spy::operating_system == spy::linux_));
-    assert(!(spy::operating_system == spy::macos_));
-    assert(!(spy::operating_system == spy::unix_));
-    assert(spy::operating_system == spy::windows_);
+    SPY_ASSERT("the system is not android", !(spy::operating_system == spy::android_));
+    SPY_ASSERT("the system is not bsd", !(spy::operating_system == spy::bsd_));
+    SPY_ASSERT("the system is not cygwin", !(spy::operating_system == spy::cygwin_));
+    SPY_ASSERT("the system is not ios", !(spy::operating_system == spy::ios_));
+    SPY_ASSERT("the system is not linux", !(spy::operating_system == spy::linux_));
+    SPY_ASSERT("the system is not macos", !(spy::operating_system == spy::macos_));
+    SPY_ASSERT("the system is not unix", !(spy::operating_system == spy::unix_));
+    SPY_ASSERT("the system is windows", spy::operating_system == spy::windows_);
 #endif
   }
-  std::cout << "Done." << std::endl;
   std::cout << "Detected OS: " << spy::operating_system << std::endl;
 }

--- a/test/unit/simd.cpp
+++ b/test/unit/simd.cpp
@@ -5,7 +5,6 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
 

--- a/test/unit/stdlib.cpp
+++ b/test/unit/stdlib.cpp
@@ -5,30 +5,30 @@
   SPDX-License-Identifier: BSL-1.0
 **/
 //==================================================================================================
-#include <cassert>
 #include <iostream>
 #include <spy/spy.hpp>
 
+#include "assert.hpp"
+
 int main()
 {
-  std::cout << "Check that detected stdlib is correct: " << std::flush;
+  std::cout << "== detected stdlib is correct\n";
   {
 #if defined(_LIBCPP_VERSION)
     {
-      assert(spy::stdlib == spy::libcpp_);
-      assert(!(spy::stdlib == spy::gnucpp_));
+      SPY_ASSERT("the standard library is libc++", spy::stdlib == spy::libcpp_);
+      SPY_ASSERT("the standard library is not libstdc++", !(spy::stdlib == spy::gnucpp_));
     }
 #elif defined(__GLIBCXX__)
     {
-      assert(!(spy::stdlib == spy::libcpp_));
-      assert(spy::stdlib == spy::gnucpp_);
+      SPY_ASSERT("the standard library is not libc++", !(spy::stdlib == spy::libcpp_));
+      SPY_ASSERT("the standard library is libstdc++", spy::stdlib == spy::gnucpp_);
     }
 #endif
   }
-  std::cout << "Done." << std::endl;
   std::cout << "Detected stdlib: " << spy::stdlib << std::endl;
 
-  std::cout << "Check that detected constexpr selection on exact stdlib is correct: " << std::flush;
+  std::cout << "== detected constexpr selection on exact stdlib is correct\n";
   {
     using namespace spy::literal;
 
@@ -42,12 +42,11 @@ int main()
 
     if constexpr(spy::stdlib)
     {
-      assert(!bool(wrong_constexpr_behavior));
+      SPY_ASSERT("a version that does not match is turned down", !bool(wrong_constexpr_behavior));
     }
     else
     {
-      assert(bool(wrong_constexpr_behavior));
+      SPY_ASSERT("a version that does not match selects nothing", bool(wrong_constexpr_behavior));
     }
   }
-  std::cout << "Done." << std::endl;
 }


### PR DESCRIPTION
The matrix ran no test from copacabana v7 on: a row saying nothing about `test` read as null, which
GitHub compares equal to false. This pin is what brings the tests back, so the jobs of this
repository run them again for the first time since 2026-09-03.

Running them again turned up two things:

* The MINGW version floors said `15'2`, where every other floor in `unit/compiler.cpp` is an old
  release, `7'2_gcc` or `3'9_clang`. The runner carries MinGW-w64 14.2, and that assertion had never
  run. They now say `7'2`, which is what a MINGW version is compared against: a gcc one.
* `assert` is compiled out under `NDEBUG`, so the Release half of the matrix only ever checked that
  the tests build. `test/assert.hpp` holds a `spy::check` that takes the condition as a template
  argument, which refuses one that is not a constant expression, prints what it looked at either
  way, and aborts on a failure whatever the configuration. The nine unit tests use it.
