### PR TITLE
Version 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ copa_add_option(SPY_ENABLE_COVERAGE "Build tests with code coverage instrumentat
 if(SPY_BUILD_TEST)
   include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
 endif()
-copa_project_version(MAJOR 2 MINOR 0 PATCH 0 REPOSITORY https://github.com/jfalcou/spy)
+copa_project_version(MAJOR 3 MINOR 0 PATCH 0 REPOSITORY https://github.com/jfalcou/spy)
 
 ##======================================================================================================================
 ## Summary Display

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ include(FetchContent)
 FetchContent_Declare(
   spy
   GIT_REPOSITORY [https://github.com/jfalcou/spy.git](https://github.com/jfalcou/spy.git)
-  GIT_TAG        v2.0.0 # Replace with latest tag
+  GIT_TAG        3.0.0 # Replace with latest tag
 )
 FetchContent_MakeAvailable(spy)
 
@@ -88,7 +88,7 @@ target_link_libraries(your_target PRIVATE spy::spy)
 CPMAddPackage(
   NAME spy
   GITHUB_REPOSITORY jfalcou/spy
-  GIT_TAG v2.0.0
+  GIT_TAG 3.0.0
 )
 target_link_libraries(your_target PRIVATE spy::spy)
 ```

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -8,7 +8,7 @@
 ## reason to restate.
 ##======================================================================================================================
 
-PROJECT_BRIEF          = "Denise Bloch"
+PROJECT_BRIEF          = "Andrée Borrel"
 PROJECT_LOGO           = logo.svg
 LAYOUT_FILE            = layout.xml
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,49 @@
 Change Log {#changelog}
 ==========
 
+# Version 3.0.0 - Andrée Borrel
+
+## Changelog
+
+- **BREAKING CHANGES**
+  - Clang-CL now reports as `spy::clangcl_` and defines `SPY_COMPILER_IS_CLANGCL`. It reported as
+    `spy::msvc_` up to 2.0.0.
+  - MINGW32 and MINGW64 now report as `spy::mingw32_` and `spy::mingw64_` and define
+    `SPY_COMPILER_IS_MINGW32` or `SPY_COMPILER_IS_MINGW64`. They reported as `spy::gcc_` up to
+    2.0.0.
+
+- Features:
+  - Report the C++ standard version through `spy::cpp_standard` and the `_cpp` literal.
+  - Detect half-precision support through `spy::supports::fp16`, covering the `_Float16` type,
+    scalar and vector arithmetic, and packed conversions.
+  - Detect the x86 F16C extension through `spy::supports::f16c_`.
+  - Compiling below C++20 now stops on a diagnostic that names the required standard.
+
+- Bugs:
+  - Restore `SPY_DISABLE_ADDRESS_SANITIZERS` and `SPY_DISABLE_THREAD_SANITIZERS` under MINGW, where
+    the compiler reclassification had left them empty.
+  - Lower the MINGW version floors of the unit tests to the one gcc has, `7'2`. They asked for 15.2,
+    which no runner carries, and the assertion had never run.
+  - Give every `spy::supports` indicator one object per program. The `fp16` ones were declared
+    `static` and the sanitizer ones had no `inline`, so each translation unit held its own copy at
+    its own address.
+  - Accept both spellings of the Emscripten version macros, renamed in Emscripten 5.
+  - Compile cleanly under `-Wshadow`.
+
+- Infrastructure:
+  - Vendor CPM.cmake at v0.43.1, so a configure step no longer downloads it.
+  - Drive the CI from CMake presets and the copacabana v8 shared workflows, with coverage,
+    sanitizers, standalone generation and pre-commit checks.
+  - Add Clang-CL and MINGW64 jobs to the Windows matrix, and cover every compiler tag in the unit
+    tests.
+  - Check what a test claims under `NDEBUG` too: `assert` is compiled out in Release, so half the
+    matrix only ever checked that the tests build. `test/assert.hpp` holds a `spy::check` that takes
+    the condition as a template argument and names what it looked at either way.
+
+## Our SPY:
+
+[Andrée Borrel](https://en.wikipedia.org/wiki/Andr%C3%A9e_Borrel)
+
 # Version 2.0.0 - Denise Bloch
 
 ## Changelog

--- a/include/spy/compiler.hpp
+++ b/include/spy/compiler.hpp
@@ -160,17 +160,21 @@ namespace spy
   //!
   //! @groupheader{Supported Value}
   //!
-  //! Name              | Compiler
-  //! ----------------- | -------------
-  //! `spy::clang`      | Clang
-  //! `spy::dpcpp`      | Intel DPC++/ICPX
-  //! `spy::emscripten` | Emscripten
-  //! `spy::gcc`        | G++
-  //! `spy::intel`      | Intel ICC
-  //! `spy::msvc`       | Microsoft Visual Studio
-  //! `spy::nvcc`       | NVIDIA NVCC
-  //! `spy::mingw32`    | MINGW32
-  //! `spy::mingw64`    | MINGW64
+  //! Name                | Compiler
+  //! ------------------- | -------------
+  //! `spy::clang_`       | Clang
+  //! `spy::clangcl_`     | Clang-CL, Clang driving the Microsoft toolchain
+  //! `spy::dpcpp_`       | Intel DPC++/ICPX
+  //! `spy::emscripten_`  | Emscripten
+  //! `spy::gcc_`         | G++
+  //! `spy::intel_`       | Intel ICC
+  //! `spy::mingw32_`     | MINGW32
+  //! `spy::mingw64_`     | MINGW64
+  //! `spy::msvc_`        | Microsoft Visual Studio
+  //! `spy::nvcc_`        | NVIDIA NVCC
+  //!
+  //! Clang-CL, MINGW32 and MINGW64 each report as themselves. Under MINGW,
+  //! `spy::compiler == spy::gcc_` is false; under Clang-CL, `spy::compiler == spy::msvc_` is false.
   //!
   //! @groupheader{Example}
   //! @godbolt{samples/compiler.cpp}

--- a/include/spy/sanitizers.hpp
+++ b/include/spy/sanitizers.hpp
@@ -34,53 +34,54 @@
 namespace spy::supports
 {
 #if defined(SPY_ADDRESS_SANITIZERS_ENABLED)
-  constexpr bool address_sanitizers_status = true;
+  constexpr inline bool address_sanitizers_status = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //==================================================================================================
   //! @ingroup api
-  //! @brief Thread sanitizer status indicator.
+  //! @brief Address sanitizer status indicator.
   //!
-  //! Indicate if current code is compile using `-fsanitize=address`.
+  //! Evaluates to `true` when the current code is compiled with `-fsanitize=address`.
   //!
   //! @groupheader{Example}
   //! @godbolt{samples/sanitizers.cpp}
   //==================================================================================================
-  constexpr bool address_sanitizers_status = _::implementation_defined {};
+  constexpr inline bool address_sanitizers_status = _::implementation_defined {};
 #else
-  constexpr bool address_sanitizers_status = false;
+  constexpr inline bool address_sanitizers_status = false;
 #endif
 
 #if defined(SPY_THREAD_SANITIZERS_ENABLED)
-  constexpr bool thread_sanitizers_status = true;
+  constexpr inline bool thread_sanitizers_status = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //==================================================================================================
   //! @ingroup api
   //! @brief Thread sanitizer status indicator.
   //!
-  //! Indicate if current code is compile using `-fsanitize=threads`.
+  //! Evaluates to `true` when the current code is compiled with `-fsanitize=thread`.
   //!
   //! @groupheader{Example}
   //! @godbolt{samples/sanitizers.cpp}
   //==================================================================================================
-  constexpr bool thread_sanitizers_status = _::implementation_defined {};
+  constexpr inline bool thread_sanitizers_status = _::implementation_defined {};
 #else
-  constexpr bool thread_sanitizers_status = false;
+  constexpr inline bool thread_sanitizers_status = false;
 #endif
 
   //==================================================================================================
   //! @ingroup api
   //! @brief Sanitizers status indicator.
   //!
-  //! Aggregate the status of all detected sanitizers
+  //! Evaluates to `true` when any of the sanitizers spy detects is enabled.
   //!
   //! @groupheader{Example}
   //! @godbolt{samples/sanitizers.cpp}
   //==================================================================================================
-  constexpr bool sanitizers_status = address_sanitizers_status || thread_sanitizers_status;
+  constexpr inline bool sanitizers_status = address_sanitizers_status || thread_sanitizers_status;
 }
 
 #if defined(SPY_COMPILER_IS_CLANG) || defined(SPY_COMPILER_IS_GCC) ||                              \
-    defined(SPY_COMPILER_IS_CLANGCL)
+    defined(SPY_COMPILER_IS_CLANGCL) || defined(SPY_COMPILER_IS_MINGW32) ||                        \
+    defined(SPY_COMPILER_IS_MINGW64)
 #define SPY_DISABLE_ADDRESS_SANITIZERS __attribute__((no_sanitize_address))
 #define SPY_DISABLE_THREAD_SANITIZERS  __attribute__((no_sanitize_thread))
 #elif defined(SPY_COMPILER_IS_MSVC)

--- a/include/spy/simd.hpp
+++ b/include/spy/simd.hpp
@@ -218,7 +218,7 @@ namespace spy
 //!
 //! | Architecture  | Supported SIMD instructions sets |
 //! | ------------- | ------------------------------------------------------------------------------------------------|
-//! | **X86 AVX**   | `xop_`, `fma_`, `fma4_`                                                                         |
+//! | **X86 AVX**   | `xop_`, `fma_`, `fma4_`, `f16c_`                                                                |
 //! | **X86 AVX512**| `bw_`, `cd_`, `dq_`, `er_`, `ifma_`, `pf_`, `vl_`, `popcntdq_`, `_4fmaps_`, `vnniw_`, `vbmi_`   |
 //! |               | `bf16_`, `bitalg_`, `vbmi2_`, `vnni_`, `vpintersect_`                                           |
 //!

--- a/include/spy/standard.hpp
+++ b/include/spy/standard.hpp
@@ -66,8 +66,11 @@ namespace spy
   //! @ingroup api
   //! @brief C++ standard version reporting value
   //!
-  //! The `spy::current_standard` object can be compared to any other current_standard related value
-  //! to verify if the code being compiled with a specific version of the C++ standard.
+  //! The `spy::cpp_standard` object can be compared to any other C++ standard related value to
+  //! verify if the code being compiled with a specific version of the C++ standard. It reports
+  //! `20`, `23` or `26`, and `0` when the standard version is unknown.
+  //!
+  //! The targeted version is specified either as an integer or with the `_cpp` literal.
   //!
   //! @groupheader{Example}
   //! @godbolt{samples/standard.cpp}

--- a/include/spy/types.hpp
+++ b/include/spy/types.hpp
@@ -52,34 +52,77 @@
 
 namespace spy::supports::fp16
 {
-  //! Whether the _Float16 type is provided by the compiler on the current platform.
-#ifdef SPY_SUPPORTS_FP16_TYPE
-  static constexpr bool type = true;
+#if defined(SPY_SUPPORTS_FP16_TYPE)
+  constexpr inline bool type = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup api
+  //! @brief Half-precision type availability indicator
+  //!
+  //! Evaluates to `true` when the `_Float16` type is provided by the compiler on the current
+  //! platform. The three other indicators of this namespace are meaningful only when this one
+  //! is `true`.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/fp16.cpp}
+  //================================================================================================
+  constexpr inline bool type = _::implementation_defined {};
 #else
-  static constexpr bool type = false;
+  constexpr inline bool type = false;
 #endif
 
-  //! Whether the current architecture supports scalar operations on IEEE-754 half-precision
-  //! floating-point numbers.
-#ifdef SPY_SUPPORTS_FP16_SCALAR_OPS
-  static constexpr bool scalar_ops = true;
+#if defined(SPY_SUPPORTS_FP16_SCALAR_OPS)
+  constexpr inline bool scalar_ops = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup api
+  //! @brief Half-precision scalar arithmetic indicator
+  //!
+  //! Evaluates to `true` when the current architecture supports scalar operations on IEEE-754
+  //! half-precision floating-point numbers.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/fp16.cpp}
+  //================================================================================================
+  constexpr inline bool scalar_ops = _::implementation_defined {};
 #else
-  static constexpr bool scalar_ops = false;
+  constexpr inline bool scalar_ops = false;
 #endif
 
-  //! Whether the current architecture supports packed conversion operations between IEEE-754
-  //! half-precision floating-point numbers and at least one other IEEE-754 floating-point type.
-#ifdef SPY_SUPPORTS_FP16_VECTOR_CONVERSION
-  static constexpr bool vector_conversion = true;
+#if defined(SPY_SUPPORTS_FP16_VECTOR_CONVERSION)
+  constexpr inline bool vector_conversion = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup api
+  //! @brief Half-precision packed conversion indicator
+  //!
+  //! Evaluates to `true` when the current architecture supports packed conversion operations
+  //! between IEEE-754 half-precision floating-point numbers and at least one other IEEE-754
+  //! floating-point type. It is implied by @ref spy::supports::fp16::vector_ops.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/fp16.cpp}
+  //================================================================================================
+  constexpr inline bool vector_conversion = _::implementation_defined {};
 #else
-  static constexpr bool vector_conversion = false;
+  constexpr inline bool vector_conversion = false;
 #endif
 
-  //! Whether the current architecture supports vector operations on IEEE-754 half-precision
-  //! floating-point numbers.
-#ifdef SPY_SUPPORTS_FP16_VECTOR_OPS
-  static constexpr bool vector_ops = true;
+#if defined(SPY_SUPPORTS_FP16_VECTOR_OPS)
+  constexpr inline bool vector_ops = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup api
+  //! @brief Half-precision vector arithmetic indicator
+  //!
+  //! Evaluates to `true` when the current architecture supports vector operations on IEEE-754
+  //! half-precision floating-point numbers.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/fp16.cpp}
+  //================================================================================================
+  constexpr inline bool vector_ops = _::implementation_defined {};
 #else
-  static constexpr bool vector_ops = false;
+  constexpr inline bool vector_ops = false;
 #endif
 }

--- a/test/samples/fp16.cpp
+++ b/test/samples/fp16.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <spy/spy.hpp>
+
+int main()
+{
+  if constexpr(spy::supports::fp16::type)
+  {
+    std::cout << "_Float16 is available.\n";
+
+    if constexpr(spy::supports::fp16::scalar_ops)
+      std::cout << "Scalar half-precision arithmetic is available.\n";
+
+    if constexpr(spy::supports::fp16::vector_ops)
+      std::cout << "Vector half-precision arithmetic is available.\n";
+    else if constexpr(spy::supports::fp16::vector_conversion)
+      std::cout << "Packed half-precision conversions are available.\n";
+  }
+  else
+  {
+    std::cout << "_Float16 is not available.\n";
+  }
+}


### PR DESCRIPTION
Clang-CL is reported as `spy::clangcl_` and MINGW as `spy::mingw32_` or `spy::mingw64_` since
2.0.0, where the first passed for MSVC and the second for g++. Nothing was removed and no enum was
renumbered, but a guard written on `spy::gcc_` turns false under MINGW without a warning, which is
nbig enough to warrant a major version.

The three commits are : 
 + the release itself
 + the documentation of the API brought back in line with the code, and the defect that reclassification left behind: MINGW had dropped out of the list guarding `SPY_DISABLE_ADDRESS_SANITIZERS`, so the macro expanded to nothing there. 
+ The seven `spy::supports` indicators take that pass too, four declared `static` and three without `inline`, each translation unit holding its own copy at its own address.
