### PR TITLE
Run the matrix nightly, and say so in the README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@
 ##======================================================================================================================
 name: Unit Tests
 on:
+  ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
+  ## the pull requests back. 02:20 UTC, which is 03:20 in Paris in winter, an hour after kumi so the two do not
+  ## ask for the self-hosted agents at once, and off the hour that every other scheduled workflow asks for.
+  schedule:
+    - cron: '20 2 * * *'
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # SPY: C++ Information Broker
 
+[![Release](https://img.shields.io/github/v/release/jfalcou/spy?style=plastic&label=release)](https://github.com/jfalcou/spy/releases/latest)
 [![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
 [![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.gg/a9qVaEMeXd8)
-[![CI Status](https://github.com/jfalcou/spy/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/spy/actions/workflows/integration.yml)
+[![Integration](https://github.com/jfalcou/spy/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/spy/actions/workflows/integration.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/spy/coverage/badge.json&style=plastic&cacheSeconds=1800)](https://jfalcou.github.io/spy/coverage/)
+[![CI](https://github.com/jfalcou/spy/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/jfalcou/spy/actions/workflows/ci.yml?query=event%3Aschedule)
 
 <br clear="left"/>
 


### PR DESCRIPTION
`ci.yml` runs on a schedule at 02:20 UTC as well as on pull requests, an hour after kumi so the two
do not ask for the self-hosted agents at once. A broken `main` shows the next morning rather than
never: nothing triggers this matrix on a merge today, and a run of its own on every merge held the
pull requests back when kumi tried it.

The README carries six badges in the order kumi settled on: release, license, Discord, Integration,
Coverage and CI. The badge that read "CI Status" pointed at the integration workflow, so it
announced integration under the name of the CI; it takes its real name back, and the new CI badge
reads `ci.yml` filtered on the schedule, showing the night rather than whichever pull request ran
last.
