### PR TITLE
Exclude spy::_ from the documentation

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -19,7 +19,7 @@ EXAMPLE_PATH           = ../test .
 FILE_PATTERNS          = *.hpp *.md
 
 ## The implementation namespace is not part of the interface
-EXCLUDE_SYMBOLS        = detail*
+EXCLUDE_SYMBOLS        = spy::_*
 
 TOC_INCLUDE_HEADINGS   = 5
 GENERATE_LATEX         = NO


### PR DESCRIPTION
The pattern named `detail`, a namespace renamed to `_` in 2.0.0, so it excluded nothing. `spy::_*`
names what the implementation namespace is called now.

The generated site does not change. What keeps that namespace out of the pages today is
`EXTRACT_ALL` staying off over entities that carry no doxygen block, plus copacabana's input filter
rewriting every `_::name` mention into a neutral token. The pattern is the guard for the day a
doxygen block lands on one of those entities.
