### PR TITLE
Give every navigation tab a page of its own

### DIFF
--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -4,7 +4,7 @@
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
     <tab type="user" url="@ref api"   title="Main API"/>
-    <tab type="usergroup" visible="yes" title="About The Library">
+    <tab type="usergroup" visible="yes" title="About The Library" url="@ref setup">
       <tab type="user" url="@ref setup"     title="Setup"/>
       <tab type="user" url="@ref changelog" title="Changelog"/>
       <tab type="user" url="@ref licence"   title="Licence"/>


### PR DESCRIPTION
A container tab carrying no `url` is served as `usergroupN.html`, numbered by position, so inserting an entry moves what an existing link points to. Every container now names a page, the way kumi settled it in jfalcou/kumi#251.

The commit is marked `[no ci]`, so nothing reports and the barrier never lifts. The documentation was rebuilt locally in its place: no doxygen warning, so no reference dangles, and no `usergroup*.html` is left in the output.
