### PR TITLE
Let the documentation be rebuilt on demand

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches:
       - main
+  ## Rebuilds and redeploys the published site without a commit, for when a push skipped this workflow.
+  workflow_dispatch:
 
 jobs:
   documentation:


### PR DESCRIPTION
A push whose message carries `[no ci]` skips every workflow, so the published site stays one build
behind with nothing able to rebuild it. That is how `usergroup0.html` outlived the layout change
that removed it.

The deploying job of copacabana's workflow is guarded by `github.event_name != 'pull_request'`, so a
run started by hand deploys like a push does, and nothing changes on copacabana's side.
