### PR TITLE
Group the API documentation and document the supplemental indicators

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -31,3 +31,6 @@ GENERATE_LATEX         = NO
 
 ## The image the social card metadata in head.html points at, published beside the pages.
 HTML_EXTRA_FILES      += card.png
+
+## The API groups read in the order the axes are declared, the one the navigation panel shows, rather than alphabetically.
+SORT_GROUP_NAMES       = NO

--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -157,6 +157,7 @@
   <!-- Layout definition for a group page -->
   <group>
     <briefdescription visible="yes"/>
+    <detaileddescription title=""/>
     <groupgraph visible="$GROUP_GRAPHS"/>
     <memberdecl>
       <nestedgroups visible="yes" title=""/>

--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -3,7 +3,14 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="user" url="@ref api"   title="Main API"/>
+    <tab type="usergroup" visible="yes" title="Main API" url="@ref api">
+      <tab type="user" url="@ref spy_platform"    title="Target Platforms"/>
+      <tab type="user" url="@ref spy_compiler"    title="Compilers"/>
+      <tab type="user" url="@ref spy_standards"   title="Language Standards"/>
+      <tab type="user" url="@ref spy_isa"         title="Instruction Sets"/>
+      <tab type="user" url="@ref spy_accelerator" title="Accelerators"/>
+      <tab type="user" url="@ref spy_sanitizers"  title="Sanitizers"/>
+    </tab>
     <tab type="usergroup" visible="yes" title="About The Library" url="@ref setup">
       <tab type="user" url="@ref setup"     title="Setup"/>
       <tab type="user" url="@ref changelog" title="Changelog"/>

--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -7,7 +7,9 @@
       <tab type="user" url="@ref spy_platform"    title="Target Platforms"/>
       <tab type="user" url="@ref spy_compiler"    title="Compilers"/>
       <tab type="user" url="@ref spy_standards"   title="Language Standards"/>
-      <tab type="user" url="@ref spy_isa"         title="Instruction Sets"/>
+      <tab type="usergroup" visible="yes" title="Instruction Sets" url="@ref spy_isa">
+        <tab type="user" url="@ref spy_isa_supplemental" title="Supplemental Instruction Sets"/>
+      </tab>
       <tab type="user" url="@ref spy_accelerator" title="Accelerators"/>
       <tab type="user" url="@ref spy_sanitizers"  title="Sanitizers"/>
     </tab>

--- a/include/spy/accelerator.hpp
+++ b/include/spy/accelerator.hpp
@@ -57,7 +57,7 @@ namespace spy::supports
       sycl_t<SYCL_LANGUAGE_VERSION / 100, SYCL_LANGUAGE_VERSION % 100, 0> {};
 #elif defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_accelerator
   //! @brief SYCL usage indicator.
   //!
   //! Retrieves the information about wether or not current file is compiled with SYCL supports.
@@ -82,7 +82,7 @@ namespace spy::supports
 #endif
 #elif defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_accelerator
   //! @brief CUDA usage indicator.
   //!
   //! Retrieves the information about wether or not current file is compiled using NVCC.

--- a/include/spy/arch.hpp
+++ b/include/spy/arch.hpp
@@ -77,7 +77,7 @@ namespace spy
 #endif
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_platform
   //! @brief Architecture reporting value
   //!
   //! The `spy::architecture` object can be compared to any other architecture related value to

--- a/include/spy/compiler.hpp
+++ b/include/spy/compiler.hpp
@@ -146,7 +146,7 @@ namespace spy
 #endif
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief Compiler reporting value
   //!
   //! The `spy::compiler` object can be compared to any other compiler related value to verify
@@ -210,67 +210,67 @@ namespace spy
 
 namespace spy::literal
 {
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for NVCC version definition
   template<char... c> constexpr auto operator""_nvcc()
   {
     return _::literal_wrap<_::nvcc_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for MSVC version definition
   template<char... c> constexpr auto operator""_msvc()
   {
     return _::literal_wrap<_::msvc_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for MINGW32 version definition
   template<char... c> constexpr auto operator""_mingw32()
   {
     return _::literal_wrap<_::mingw32_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for MINGW64 version definition
   template<char... c> constexpr auto operator""_mingw64()
   {
     return _::literal_wrap<_::mingw64_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for Intel ICC version definition
   template<char... c> constexpr auto operator""_intel()
   {
     return _::literal_wrap<_::intel_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for Intel DCP++/ICPX version definition
   template<char... c> constexpr auto operator""_dpcpp()
   {
     return _::literal_wrap<_::dpcpp_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for Clang version definition
   template<char... c> constexpr auto operator""_clang()
   {
     return _::literal_wrap<_::clang_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for G++ version definition
   template<char... c> constexpr auto operator""_gcc() { return _::literal_wrap<_::gcc_t, c...>(); }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for Emscripten version definition
   template<char... c> constexpr auto operator""_em()
   {
     return _::literal_wrap<_::emscripten_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_compiler
   //! @brief User-defined suffix for ClangCL version definition
   template<char... c> constexpr auto operator""_clangcl()
   {

--- a/include/spy/data_model.hpp
+++ b/include/spy/data_model.hpp
@@ -42,7 +42,7 @@ namespace spy
       _::data_model_info<sizeof(short), sizeof(int), sizeof(long), sizeof(void*)>;
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_platform
   //! @brief Data Model reporting value
   //!
   //! The `spy::data_model` object can be compared to any other data model related value to verify

--- a/include/spy/libc.hpp
+++ b/include/spy/libc.hpp
@@ -102,7 +102,7 @@ namespace spy
 #endif
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief LIBC version reporting value
   //!
   //! The `spy::libc` object can be compared to any other libc related value to verify
@@ -153,26 +153,26 @@ namespace spy
 
 namespace spy::literal
 {
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief User-defined suffix for the CloudABI libc version definition
   template<char... c> constexpr auto operator""_cloud()
   {
     return _::literal_wrap<_::cloudabi_t, c...>();
   }
 
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief User-defined suffix for the uClibc version definition
   template<char... c> constexpr auto operator""_uc() { return _::literal_wrap<_::uc_t, c...>(); }
 
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief User-defined suffix for the VMS libc version definition
   template<char... c> constexpr auto operator""_vms() { return _::literal_wrap<_::vms_t, c...>(); }
 
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief User-defined suffix for the zOS libc version definition
   template<char... c> constexpr auto operator""_zos() { return _::literal_wrap<_::zos_t, c...>(); }
 
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief User-defined suffix for the GNU libc version definition
   template<char... c> constexpr auto operator""_gnu() { return _::literal_wrap<_::gnu_t, c...>(); }
 }

--- a/include/spy/os.hpp
+++ b/include/spy/os.hpp
@@ -87,7 +87,7 @@ namespace spy
 #endif
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_platform
   //! @brief OS reporting value
   //!
   //! The `spy::operating_system` object can be compared to any other OS related value to verify
@@ -139,7 +139,7 @@ namespace spy::supports
 {
 #if defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_platform
   //! @brief POSIX supports indicator.
   //!
   //! Evaluates to `true` if current OS supports POSIX system calls and functions.

--- a/include/spy/sanitizers.hpp
+++ b/include/spy/sanitizers.hpp
@@ -37,7 +37,7 @@ namespace spy::supports
   constexpr inline bool address_sanitizers_status = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //==================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_sanitizers
   //! @brief Address sanitizer status indicator.
   //!
   //! Evaluates to `true` when the current code is compiled with `-fsanitize=address`.
@@ -54,7 +54,7 @@ namespace spy::supports
   constexpr inline bool thread_sanitizers_status = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //==================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_sanitizers
   //! @brief Thread sanitizer status indicator.
   //!
   //! Evaluates to `true` when the current code is compiled with `-fsanitize=thread`.
@@ -68,7 +68,7 @@ namespace spy::supports
 #endif
 
   //==================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_sanitizers
   //! @brief Sanitizers status indicator.
   //!
   //! Evaluates to `true` when any of the sanitizers spy detects is enabled.

--- a/include/spy/simd.hpp
+++ b/include/spy/simd.hpp
@@ -166,7 +166,7 @@ namespace spy
 {
   // clang-format off
 //================================================================================================
-//! @ingroup api
+//! @ingroup spy_isa
 //! @brief SIMD extensions set  reporting value
 //!
 //! @groupheader{SIMD Instructions Sets}

--- a/include/spy/simd.hpp
+++ b/include/spy/simd.hpp
@@ -213,16 +213,13 @@ namespace spy
 //!
 //! @groupheader{Supplemental Instructions sets}
 //!
-//! Some SIMD instructions set provides supplemental instructions on top of existing system.
-//! Those supplemental instruction set can be checked using the `spy::supports` namespace.
+//! Some SIMD instructions sets provide supplemental instructions on top of an existing one. The
+//! `spy::supports` namespace carries one indicator per supplemental set, `spy::supports::fma_`,
+//! `spy::supports::fma4_`, `spy::supports::xop_` and `spy::supports::f16c_` for the AVX family, and
+//! the `spy::supports::avx512` namespace for the AVX-512 subsets. Each of them is documented on its
+//! own in this group.
 //!
-//! | Architecture  | Supported SIMD instructions sets |
-//! | ------------- | ------------------------------------------------------------------------------------------------|
-//! | **X86 AVX**   | `xop_`, `fma_`, `fma4_`, `f16c_`                                                                |
-//! | **X86 AVX512**| `bw_`, `cd_`, `dq_`, `er_`, `ifma_`, `pf_`, `vl_`, `popcntdq_`, `_4fmaps_`, `vnniw_`, `vbmi_`   |
-//! |               | `bf16_`, `bitalg_`, `vbmi2_`, `vnni_`, `vpintersect_`                                           |
-//!
-//! @subgroupheader{Example - SIMD Architectures}
+//! @subgroupheader{Example - Supplemental Instructions Sets}
 //! @godbolt{samples/simd-additional.cpp}
 //!
 //================================================================================================

--- a/include/spy/simd/x86.hpp
+++ b/include/spy/simd/x86.hpp
@@ -129,144 +129,368 @@ namespace spy::supports
   //================================================================================================
 #if defined(__FMA__)
 #define SPY_SIMD_SUPPORTS_FMA
-  constexpr inline auto fma_ = true;
+  constexpr inline bool fma_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup spy_isa_supplemental
+  //! @brief Fused multiply-add availability indicator
+  //!
+  //! Evaluates to `true` when the FMA3 instructions of the AVX family are enabled.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/simd-additional.cpp}
+  //================================================================================================
+  constexpr inline bool fma_ = _::implementation_defined {};
 #else
-  constexpr inline auto fma_ = false;
+  constexpr inline bool fma_ = false;
 #endif
 
 #if defined(__FMA4__)
 #define SPY_SIMD_SUPPORTS_FMA4
-  constexpr inline auto fma4_ = true;
+  constexpr inline bool fma4_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup spy_isa_supplemental
+  //! @brief FMA4 availability indicator
+  //!
+  //! Evaluates to `true` when the FMA4 instructions of AMD's AVX implementation are enabled.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/simd-additional.cpp}
+  //================================================================================================
+  constexpr inline bool fma4_ = _::implementation_defined {};
 #else
-  constexpr inline auto fma4_ = false;
+  constexpr inline bool fma4_ = false;
 #endif
 
 #if defined(__XOP__)
 #define SPY_SIMD_SUPPORTS_XOP
-  constexpr inline auto xop_ = true;
+  constexpr inline bool xop_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup spy_isa_supplemental
+  //! @brief XOP availability indicator
+  //!
+  //! Evaluates to `true` when the XOP instructions of AMD's AVX implementation are enabled.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/simd-additional.cpp}
+  //================================================================================================
+  constexpr inline bool xop_ = _::implementation_defined {};
 #else
-  constexpr inline auto xop_ = false;
+  constexpr inline bool xop_ = false;
 #endif
 
 #if defined(__F16C__)
 #define SPY_SIMD_SUPPORTS_F16C
-  constexpr inline auto f16c_ = true;
+  constexpr inline bool f16c_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+  //================================================================================================
+  //! @ingroup spy_isa_supplemental
+  //! @brief Half-precision conversion availability indicator
+  //!
+  //! Evaluates to `true` when the F16C instructions converting between half and single
+  //! precision are enabled.
+  //!
+  //! @groupheader{Example}
+  //! @godbolt{samples/simd-additional.cpp}
+  //================================================================================================
+  constexpr inline bool f16c_ = _::implementation_defined {};
 #else
-  constexpr inline auto f16c_ = false;
+  constexpr inline bool f16c_ = false;
 #endif
 
   namespace avx512
   {
 #if defined(__AVX512BW__)
 #define SPY_SIMD_IS_X86_AVX512_BW
-    constexpr inline auto bw_ = true;
+    constexpr inline bool bw_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Byte and Word availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Byte and Word subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool bw_ = _::implementation_defined {};
 #else
-    constexpr inline auto bw_ = false;
+    constexpr inline bool bw_ = false;
 #endif
 
 #if defined(__AVX512CD__)
 #define SPY_SIMD_IS_X86_AVX512_CD
-    constexpr inline auto cd_ = true;
+    constexpr inline bool cd_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Conflict Detection availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Conflict Detection subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool cd_ = _::implementation_defined {};
 #else
-    constexpr inline auto cd_ = false;
+    constexpr inline bool cd_ = false;
 #endif
 
 #if defined(__AVX512DQ__)
 #define SPY_SIMD_IS_X86_AVX512_DQ
-    constexpr inline auto dq_ = true;
+    constexpr inline bool dq_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Doubleword and Quadword availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Doubleword and Quadword subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool dq_ = _::implementation_defined {};
 #else
-    constexpr inline auto dq_ = false;
+    constexpr inline bool dq_ = false;
 #endif
 
 #if defined(__AVX512ER__)
 #define SPY_SIMD_IS_X86_AVX512_ER
-    constexpr inline auto er_ = true;
+    constexpr inline bool er_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Exponential and Reciprocal availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Exponential and Reciprocal subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool er_ = _::implementation_defined {};
 #else
-    constexpr inline auto er_ = false;
+    constexpr inline bool er_ = false;
 #endif
 
 #if defined(__AVX512IFMA__)
 #define SPY_SIMD_IS_X86_AVX512_IFMA
-    constexpr inline auto ifma_ = true;
+    constexpr inline bool ifma_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Integer Fused Multiply-Add availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Integer Fused Multiply-Add subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool ifma_ = _::implementation_defined {};
 #else
-    constexpr inline auto ifma_ = false;
+    constexpr inline bool ifma_ = false;
 #endif
 
 #if defined(__AVX512PF__)
 #define SPY_SIMD_IS_X86_AVX512_PF
-    constexpr inline auto pf_ = true;
+    constexpr inline bool pf_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Prefetch availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Prefetch subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool pf_ = _::implementation_defined {};
 #else
-    constexpr inline auto pf_ = false;
+    constexpr inline bool pf_ = false;
 #endif
 
 #if defined(__AVX512VL__)
 #define SPY_SIMD_IS_X86_AVX512_VL
-    constexpr inline auto vl_ = true;
+    constexpr inline bool vl_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Vector Length availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Vector Length subset, which applies the AVX-512
+    //! instructions to 128 and 256 bit registers, is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool vl_ = _::implementation_defined {};
 #else
-    constexpr inline auto vl_ = false;
+    constexpr inline bool vl_ = false;
 #endif
 
 #if defined(__AVX512VPOPCNTDQ__)
 #define SPY_SIMD_IS_X86_AVX512_POPCNTDQ
-    constexpr inline auto popcntdq_ = true;
+    constexpr inline bool popcntdq_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 population count availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 population count subset for doubleword and quadword
+    //! elements is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool popcntdq_ = _::implementation_defined {};
 #else
-    constexpr inline auto popcntdq_ = false;
+    constexpr inline bool popcntdq_ = false;
 #endif
 
 #if defined(__AVX5124FMAPS__)
 #define SPY_SIMD_IS_X86_AVX512_4FMAPS
-    constexpr inline auto _4fmaps_ = true;
+    constexpr inline bool _4fmaps_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 4FMAPS availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 four-iteration packed single-precision fused
+    //! multiply-add subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool _4fmaps_ = _::implementation_defined {};
 #else
-    constexpr inline auto _4fmaps_ = false;
+    constexpr inline bool _4fmaps_ = false;
 #endif
 
 #if defined(__AVX5124VNNIW__)
 #define SPY_SIMD_IS_X86_AVX512_VNNIW
-    constexpr inline auto vnniw_ = true;
+    constexpr inline bool vnniw_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 4VNNIW availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 four-iteration word neural network subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool vnniw_ = _::implementation_defined {};
 #else
-    constexpr inline auto vnniw_ = false;
+    constexpr inline bool vnniw_ = false;
 #endif
 
 #if defined(__AVX512VBMI__)
 #define SPY_SIMD_IS_X86_AVX512_VBMI
-    constexpr inline auto vbmi_ = true;
+    constexpr inline bool vbmi_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Vector Byte Manipulation availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Vector Byte Manipulation subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool vbmi_ = _::implementation_defined {};
 #else
-    constexpr inline auto vbmi_ = false;
+    constexpr inline bool vbmi_ = false;
 #endif
 
 #if defined(__AVX512BF16__)
 #define SPY_SIMD_IS_X86_AVX512_BF16
-    constexpr inline auto bf16_ = true;
+    constexpr inline bool bf16_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 bfloat16 availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 bfloat16 subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool bf16_ = _::implementation_defined {};
 #else
-    constexpr inline auto bf16_ = false;
+    constexpr inline bool bf16_ = false;
 #endif
 
 #if defined(__AVX512BITALG__)
 #define SPY_SIMD_IS_X86_AVX512_BITALG
-    constexpr inline auto bitalg_ = true;
+    constexpr inline bool bitalg_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Bit Algorithms availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Bit Algorithms subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool bitalg_ = _::implementation_defined {};
 #else
-    constexpr inline auto bitalg_ = false;
+    constexpr inline bool bitalg_ = false;
 #endif
 
 #if defined(__AVX512VBMI2__)
 #define SPY_SIMD_IS_X86_AVX512_VBMI2
-    constexpr inline auto vbmi2_ = true;
+    constexpr inline bool vbmi2_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Vector Byte Manipulation 2 availability indicator
+    //!
+    //! Evaluates to `true` when the second AVX-512 Vector Byte Manipulation subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool vbmi2_ = _::implementation_defined {};
 #else
-    constexpr inline auto vbmi2_ = false;
+    constexpr inline bool vbmi2_ = false;
 #endif
 
 #if defined(__AVX512VNNI__)
 #define SPY_SIMD_IS_X86_AVX512_VNNI
-    constexpr inline auto vnni_ = true;
+    constexpr inline bool vnni_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 Vector Neural Network availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 Vector Neural Network subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool vnni_ = _::implementation_defined {};
 #else
-    constexpr inline auto vnni_ = false;
+    constexpr inline bool vnni_ = false;
 #endif
 
 #if defined(__AVX512VP2INTERSECT__)
 #define SPY_SIMD_IS_X86_AVX512_VP2INTERSECT
-    constexpr inline auto vpintersect_ = true;
+    constexpr inline bool vpintersect_ = true;
+#elif defined(SPY_DOXYGEN_INVOKED)
+    //==============================================================================================
+    //! @ingroup spy_isa_supplemental
+    //! @brief AVX-512 vector pair intersection availability indicator
+    //!
+    //! Evaluates to `true` when the AVX-512 vector pair intersection subset is enabled.
+    //!
+    //! @groupheader{Example}
+    //! @godbolt{samples/simd-additional.cpp}
+    //==============================================================================================
+    constexpr inline bool vpintersect_ = _::implementation_defined {};
 #else
-    constexpr inline auto vpintersect_ = false;
+    constexpr inline bool vpintersect_ = false;
 #endif
   }
 

--- a/include/spy/spy.hpp
+++ b/include/spy/spy.hpp
@@ -16,6 +16,27 @@ namespace spy
 {
   //====================================================================================================================
   //! @defgroup api Main API
+  //! @brief What spy reports, one group per detection axis
+  //!
+  //! @{
+  //!   @defgroup spy_platform Target Platforms
+  //!   @brief The system, the processor and the data model the code is compiled for
+  //!
+  //!   @defgroup spy_compiler Compilers
+  //!   @brief The compiler processing the code, and the literals naming its versions
+  //!
+  //!   @defgroup spy_standards Language Standards
+  //!   @brief The C++ standard in force, and the C and C++ standard library implementations
+  //!
+  //!   @defgroup spy_isa Instruction Sets
+  //!   @brief The SIMD extensions the flags turn on, and what they can compute
+  //!
+  //!   @defgroup spy_accelerator Accelerators
+  //!   @brief The accelerator programming models the code is compiled with
+  //!
+  //!   @defgroup spy_sanitizers Sanitizers
+  //!   @brief The sanitizers the code is compiled with
+  //! @}
   //====================================================================================================================
 
   //====================================================================================================================

--- a/include/spy/spy.hpp
+++ b/include/spy/spy.hpp
@@ -16,26 +16,79 @@ namespace spy
 {
   //====================================================================================================================
   //! @defgroup api Main API
-  //! @brief What spy reports, one group per detection axis
+  //! @brief Everything spy reports about the target, the toolchain and the flags it was given
+  //!
+  //! Every axis spy detects is a `constexpr` object living in namespace `spy`, so a question the
+  //! preprocessor used to answer becomes a value any `constexpr` context can read. The six groups
+  //! below sort those values by the question they answer.
+  //!
+  //! A value is read in three ways, shown here on the compiler:
+  //!
+  //! @code{.cpp}
+  //! // compared to a named value
+  //! if constexpr(spy::compiler == spy::gcc_) { }
+  //!
+  //! // or the named value itself, which converts to bool
+  //! if constexpr(spy::gcc_) { }
+  //!
+  //! // and any of them prints
+  //! std::cout << spy::compiler;
+  //! @endcode
+  //!
+  //! Versions are named by a user-defined literal per vendor, gathered in `spy::literal`, and the
+  //! ordering operators compare against them:
+  //!
+  //! @code{.cpp}
+  //! using namespace spy::literal;
+  //! if constexpr(spy::compiler >= 15'0_clang) { } // clang 15 or later
+  //! @endcode
+  //!
+  //! Two different vendors compare as `std::partial_ordering::unordered` rather than as `false`, so
+  //! `spy::gcc_ < spy::clang_` has no answer instead of a wrong one.
+  //!
+  //! Capabilities that are not an axis of their own live in `spy::supports`, each a plain
+  //! `constexpr inline bool`.
   //!
   //! @{
   //!   @defgroup spy_platform Target Platforms
   //!   @brief The system, the processor and the data model the code is compiled for
   //!
+  //!   Where the code will run. `spy::operating_system` names the system and
+  //!   `spy::supports::posix_` says whether it offers a POSIX interface, `spy::architecture` names
+  //!   the processor family, and `spy::data_model` gives the sizes the ABI hands the fundamental
+  //!   types, which the system and the architecture decide together.
+  //!
   //!   @defgroup spy_compiler Compilers
   //!   @brief The compiler processing the code, and the literals naming its versions
+  //!
+  //!   `spy::compiler` reports the toolchain as itself: a compiler that imitates another still
+  //!   answers with its own name. The literals gathered here name a version to compare it against.
   //!
   //!   @defgroup spy_standards Language Standards
   //!   @brief The C++ standard in force, and the C and C++ standard library implementations
   //!
+  //!   What the code is allowed to say and what it can call: the standard the compiler was told to
+  //!   follow, and the two library implementations behind the headers it includes.
+  //!
   //!   @defgroup spy_isa Instruction Sets
   //!   @brief The SIMD extensions the flags turn on, and what they can compute
+  //!
+  //!   `spy::simd_instruction_set` names the extension the flags enabled and the width of its
+  //!   registers, and the `spy::supports::fp16` indicators say what that unit does with
+  //!   half-precision, which the same architecture macros decide.
   //!
   //!   @defgroup spy_accelerator Accelerators
   //!   @brief The accelerator programming models the code is compiled with
   //!
+  //!   These report how the current translation unit is being compiled, not what the machine
+  //!   holds: they are true when the compiler was asked for CUDA or for SYCL, whatever device is
+  //!   present.
+  //!
   //!   @defgroup spy_sanitizers Sanitizers
   //!   @brief The sanitizers the code is compiled with
+  //!
+  //!   Whether the binary carries the instrumentation of the address or the thread sanitizer, so
+  //!   that code which the instrumentation would slow down or trip can step aside at compile time.
   //! @}
   //====================================================================================================================
 

--- a/include/spy/spy.hpp
+++ b/include/spy/spy.hpp
@@ -76,6 +76,13 @@ namespace spy
   //!   `spy::simd_instruction_set` names the extension the flags enabled and the width of its
   //!   registers, and the `spy::supports::fp16` indicators say what that unit does with
   //!   half-precision, which the same architecture macros decide.
+  //!   @{
+  //!     @defgroup spy_isa_supplemental Supplemental Instruction Sets
+  //!     @brief The instructions some extensions add on top of an existing set
+  //!
+  //!     One indicator per supplemental set, `true` when the flags turned it on. The AVX family
+  //!     adds FMA3, FMA4, XOP and F16C, and the AVX-512 subsets live in their own namespace.
+  //!   @}
   //!
   //!   @defgroup spy_accelerator Accelerators
   //!   @brief The accelerator programming models the code is compiled with

--- a/include/spy/standard.hpp
+++ b/include/spy/standard.hpp
@@ -63,7 +63,7 @@ namespace spy
 #endif
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief C++ standard version reporting value
   //!
   //! The `spy::cpp_standard` object can be compared to any other C++ standard related value to
@@ -80,7 +80,7 @@ namespace spy
 
 namespace spy::literal
 {
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief User-defined suffix for C++ standard definition
   template<char... c>
     requires(sizeof...(c) == 2)

--- a/include/spy/stdlib.hpp
+++ b/include/spy/stdlib.hpp
@@ -77,7 +77,7 @@ namespace spy
 #endif
 
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_standards
   //! @brief C++ Standard Library version reporting value
   //!
   //! The `spy::stdlib` object can be compared to any other stdlib related value to verify

--- a/include/spy/types.hpp
+++ b/include/spy/types.hpp
@@ -56,7 +56,7 @@ namespace spy::supports::fp16
   constexpr inline bool type = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_isa
   //! @brief Half-precision type availability indicator
   //!
   //! Evaluates to `true` when the `_Float16` type is provided by the compiler on the current
@@ -75,7 +75,7 @@ namespace spy::supports::fp16
   constexpr inline bool scalar_ops = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_isa
   //! @brief Half-precision scalar arithmetic indicator
   //!
   //! Evaluates to `true` when the current architecture supports scalar operations on IEEE-754
@@ -93,7 +93,7 @@ namespace spy::supports::fp16
   constexpr inline bool vector_conversion = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_isa
   //! @brief Half-precision packed conversion indicator
   //!
   //! Evaluates to `true` when the current architecture supports packed conversion operations
@@ -112,7 +112,7 @@ namespace spy::supports::fp16
   constexpr inline bool vector_ops = true;
 #elif defined(SPY_DOXYGEN_INVOKED)
   //================================================================================================
-  //! @ingroup api
+  //! @ingroup spy_isa
   //! @brief Half-precision vector arithmetic indicator
   //!
   //! Evaluates to `true` when the current architecture supports vector operations on IEEE-754

--- a/include/spy/types.hpp
+++ b/include/spy/types.hpp
@@ -98,7 +98,7 @@ namespace spy::supports::fp16
   //!
   //! Evaluates to `true` when the current architecture supports packed conversion operations
   //! between IEEE-754 half-precision floating-point numbers and at least one other IEEE-754
-  //! floating-point type. It is implied by @ref spy::supports::fp16::vector_ops.
+  //! floating-point type. It is implied by spy::supports::fp16::vector_ops.
   //!
   //! @groupheader{Example}
   //! @godbolt{samples/fp16.cpp}


### PR DESCRIPTION
The Main API page listed thirty-four entries in one alphabetical run. They are now six groups, each
named after the question it answers, and the twenty supplemental instruction set indicators of
`spy::supports` and `spy::supports::avx512`, which existed only as names in a table inside another
symbol's documentation, carry their own block and sit in a subgroup of their own.

Three settings hold that structure up and are easy to undo by accident: the navigation panel shows
only what a usergroup tab lists, so `doc/layout.xml` names the groups; the `<group>` section of that
same file had no `<detaileddescription>`, so no group could show anything beyond its brief; and
`SORT_GROUP_NAMES` is off so the Main API page lists the groups in the order the panel does.
